### PR TITLE
Translate off the unused global signals

### DIFF
--- a/rel/src/vhdl/ibm/std_ulogic_function_support.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_function_support.vhdl
@@ -50,9 +50,11 @@ package std_ulogic_function_support is
   attribute tce_seqcond     : string;
 
   --  Global Signals
+  -- Synopsys translate_off
   signal audit_bit_dump    : std_ulogic ;
   signal assertion_summary : boolean    ;
   signal assertion_clock   : std_ulogic ;
+  -- Synopsys translate_on
 
   -- Synopsys translate_off
   component assertion


### PR DESCRIPTION
This is a simple change (after a few ones in ghdl) to be able to synthesize a2i using open source tools.
