### PR TITLE
Add basic CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+Contributing to a2i
+===================
+
+We work via the Github workflow. Please create GitHub issues and
+pull requests. See:
+    https://github.com/openpower-cores/a2i
+
+All contributions should have a Developer Certificate of Origin (see below).
+
+Developer Certificate of Origin
+-------------------------------
+
+Contributions to this project should conform to the `Developer Certificate
+of Origin` as defined at http://elinux.org/Developer_Certificate_Of_Origin.
+Commits to this project need to contain the following line to indicate
+the submitter accepts the DCO:
+```
+Signed-off-by: Your Name <your_email@domain.com>
+```
+By contributing in this way, you agree to the terms as follows:
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+


### PR DESCRIPTION
This adds a requirement that all contributed patches have the
Developer Certificate of Origin (ie a Signed-off-by)

Signed-off-by: Michael Neuling <mikey@neuling.org>