### PR TITLE
ci: test two GHDL backends (mcode and LLVM)

### DIFF
--- a/.github/workflows/vunit_tests.yml
+++ b/.github/workflows/vunit_tests.yml
@@ -9,10 +9,26 @@ on:
 
 jobs:
 
-  Test:
+
+  Test-mcode:
     runs-on: ubuntu-latest
+    name: 'VUnit GHDL (mcode)'
     steps:
 
     - uses: actions/checkout@v2
 
     - uses: VUnit/vunit_action@master
+      with:
+        image: ghdl/vunit:mcode-master
+
+
+  Test-llvm:
+    runs-on: ubuntu-latest
+    name: 'VUnit GHDL (LLVM)'
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: VUnit/vunit_action@master
+      with:
+        image: ghdl/vunit:llvm-master

--- a/rel/src/vhdl/clib/c_prism_bthmx.vhdl
+++ b/rel/src/vhdl/clib/c_prism_bthmx.vhdl
@@ -1,18 +1,18 @@
 -- © IBM Corp. 2020
 -- This softcore is licensed under and subject to the terms of the CC-BY 4.0
--- license (https://creativecommons.org/licenses/by/4.0/legalcode). 
--- Additional rights, including the right to physically implement a softcore 
--- that is compliant with the required sections of the Power ISA 
--- Specification, will be available at no cost via the OpenPOWER Foundation. 
--- This README will be updated with additional information when OpenPOWER's 
+-- license (https://creativecommons.org/licenses/by/4.0/legalcode).
+-- Additional rights, including the right to physically implement a softcore
+-- that is compliant with the required sections of the Power ISA
+-- Specification, will be available at no cost via the OpenPOWER Foundation.
+-- This README will be updated with additional information when OpenPOWER's
 -- license is available.
 
-library ieee; use ieee.std_logic_1164.all ; 
+library ieee; use ieee.std_logic_1164.all ;
 library ibm;
-  use ibm.std_ulogic_support.all; 
-  use ibm.std_ulogic_function_support.all; 
-  use ibm.std_ulogic_ao_support.all; 
-  use ibm.std_ulogic_mux_support.all; 
+  use ibm.std_ulogic_support.all;
+  use ibm.std_ulogic_function_support.all;
+  use ibm.std_ulogic_ao_support.all;
+  use ibm.std_ulogic_mux_support.all;
 library support; use support.power_logic_pkg.all;
 
 ENTITY c_prism_bthmx IS
@@ -32,19 +32,20 @@ ENTITY c_prism_bthmx IS
 -- synopsys translate_off
 
 
-    -- The following will be used by synthesis for unrolling the vector:
-    ATTRIBUTE PIN_BIT_INFORMATION of c_prism_bthmx : entity is
-      (
-        1 => ("   ","X       ","SAME","PIN_BIT_SCALAR"),
-        2 => ("   ","SNEG    ","SAME","PIN_BIT_SCALAR"),
-        3 => ("   ","SX      ","SAME","PIN_BIT_SCALAR"),
-        4 => ("   ","SX2     ","SAME","PIN_BIT_SCALAR"),
-        5 => ("   ","RIGHT   ","SAME","PIN_BIT_SCALAR"),
-        6 => ("   ","LEFT    ","SAME","PIN_BIT_SCALAR"),
-        7 => ("   ","Q       ","SAME","PIN_BIT_SCALAR"),
-        8 => ("   ","VDD     ","SAME","PIN_BIT_SCALAR"),
-        9 => ("   ","VSS     ","SAME","PIN_BIT_SCALAR")
-        );
+   -- The following will be used by synthesis for unrolling the vector:
+   -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+   --ATTRIBUTE PIN_BIT_INFORMATION of c_prism_bthmx : entity is
+   --  (
+   --    1 => ("   ","X       ","SAME","PIN_BIT_SCALAR"),
+   --    2 => ("   ","SNEG    ","SAME","PIN_BIT_SCALAR"),
+   --    3 => ("   ","SX      ","SAME","PIN_BIT_SCALAR"),
+   --    4 => ("   ","SX2     ","SAME","PIN_BIT_SCALAR"),
+   --    5 => ("   ","RIGHT   ","SAME","PIN_BIT_SCALAR"),
+   --    6 => ("   ","LEFT    ","SAME","PIN_BIT_SCALAR"),
+   --    7 => ("   ","Q       ","SAME","PIN_BIT_SCALAR"),
+   --    8 => ("   ","VDD     ","SAME","PIN_BIT_SCALAR"),
+   --    9 => ("   ","VSS     ","SAME","PIN_BIT_SCALAR")
+   --    );
 -- synopsys translate_on
 END                               c_prism_bthmx;
 
@@ -61,13 +62,13 @@ BEGIN
 
    SPOS <= NOT SNEG;
 
-   CENTER <= NOT( ( XN AND SPOS ) OR 
+   CENTER <= NOT( ( XN AND SPOS ) OR
                   ( X  AND SNEG )   );
 
    LEFT <= CENTER; -- OUTPUT
 
 
-   Q <= ( CENTER AND  SX  ) OR 
+   Q <= ( CENTER AND  SX  ) OR
         ( RIGHT  AND  SX2 ) ;
 
 

--- a/rel/src/vhdl/clib/c_prism_csa32.vhdl
+++ b/rel/src/vhdl/clib/c_prism_csa32.vhdl
@@ -1,18 +1,18 @@
 -- © IBM Corp. 2020
 -- This softcore is licensed under and subject to the terms of the CC-BY 4.0
--- license (https://creativecommons.org/licenses/by/4.0/legalcode). 
--- Additional rights, including the right to physically implement a softcore 
--- that is compliant with the required sections of the Power ISA 
--- Specification, will be available at no cost via the OpenPOWER Foundation. 
--- This README will be updated with additional information when OpenPOWER's 
+-- license (https://creativecommons.org/licenses/by/4.0/legalcode).
+-- Additional rights, including the right to physically implement a softcore
+-- that is compliant with the required sections of the Power ISA
+-- Specification, will be available at no cost via the OpenPOWER Foundation.
+-- This README will be updated with additional information when OpenPOWER's
 -- license is available.
 
-library ieee; use ieee.std_logic_1164.all ; 
+library ieee; use ieee.std_logic_1164.all ;
 library ibm;
-  use ibm.std_ulogic_support.all; 
-  use ibm.std_ulogic_function_support.all; 
-  use ibm.std_ulogic_ao_support.all; 
-  use ibm.std_ulogic_mux_support.all; 
+  use ibm.std_ulogic_support.all;
+  use ibm.std_ulogic_function_support.all;
+  use ibm.std_ulogic_ao_support.all;
+  use ibm.std_ulogic_mux_support.all;
 library support; use support.power_logic_pkg.all;
 
 ENTITY c_prism_csa32 IS
@@ -30,17 +30,18 @@ ENTITY c_prism_csa32 IS
 -- synopsys translate_off
 
 
-   -- The following will be used by synthesis for unrolling the vector:
-   ATTRIBUTE PIN_BIT_INFORMATION of c_prism_csa32 : entity is
-     (
-       1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-       2 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-       3 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-       4 => ("   ","CAR     ","SAME","PIN_BIT_SCALAR"),
-       5 => ("   ","SUM     ","SAME","PIN_BIT_SCALAR"),
-       6 => ("   ","VDD     ","SAME","PIN_BIT_SCALAR"),
-       7 => ("   ","VSS     ","SAME","PIN_BIT_SCALAR")
-       );
+  -- The following will be used by synthesis for unrolling the vector:
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --ATTRIBUTE PIN_BIT_INFORMATION of c_prism_csa32 : entity is
+  --  (
+  --    1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --    2 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --    3 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --    4 => ("   ","CAR     ","SAME","PIN_BIT_SCALAR"),
+  --    5 => ("   ","SUM     ","SAME","PIN_BIT_SCALAR"),
+  --    6 => ("   ","VDD     ","SAME","PIN_BIT_SCALAR"),
+  --    7 => ("   ","VSS     ","SAME","PIN_BIT_SCALAR")
+  --    );
 -- synopsys translate_on
 END                               c_prism_csa32;
 

--- a/rel/src/vhdl/clib/c_prism_csa42.vhdl
+++ b/rel/src/vhdl/clib/c_prism_csa42.vhdl
@@ -1,25 +1,25 @@
 -- © IBM Corp. 2020
 -- This softcore is licensed under and subject to the terms of the CC-BY 4.0
--- license (https://creativecommons.org/licenses/by/4.0/legalcode). 
--- Additional rights, including the right to physically implement a softcore 
--- that is compliant with the required sections of the Power ISA 
--- Specification, will be available at no cost via the OpenPOWER Foundation. 
--- This README will be updated with additional information when OpenPOWER's 
+-- license (https://creativecommons.org/licenses/by/4.0/legalcode).
+-- Additional rights, including the right to physically implement a softcore
+-- that is compliant with the required sections of the Power ISA
+-- Specification, will be available at no cost via the OpenPOWER Foundation.
+-- This README will be updated with additional information when OpenPOWER's
 -- license is available.
 
 
-library ieee; use ieee.std_logic_1164.all ; 
+library ieee; use ieee.std_logic_1164.all ;
 library support;
 library ibm;
-  use ibm.std_ulogic_support.all; 
-  use ibm.std_ulogic_function_support.all; 
-  use ibm.std_ulogic_ao_support.all; 
-  use ibm.std_ulogic_mux_support.all; 
+  use ibm.std_ulogic_support.all;
+  use ibm.std_ulogic_function_support.all;
+  use ibm.std_ulogic_ao_support.all;
+  use ibm.std_ulogic_mux_support.all;
   use support.power_logic_pkg.all;
 
 ENTITY c_prism_csa42 IS
   GENERIC ( btr : string := "CSA42_A2_A12TH" );
-  PORT( 
+  PORT(
    A       : IN  std_ulogic;
    B       : IN  std_ulogic;
    C       : IN  std_ulogic;
@@ -36,19 +36,20 @@ ENTITY c_prism_csa42 IS
 
 
   -- The following will be used by synthesis for unrolling the vector:
-   ATTRIBUTE PIN_BIT_INFORMATION of c_prism_csa42 : entity is
-     (
-       1  => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-       2  => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-       3  => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-       4  => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-       5  => ("   ","KI      ","SAME","PIN_BIT_SCALAR"),
-       6  => ("   ","KO      ","SAME","PIN_BIT_SCALAR"),
-       7  => ("   ","CAR     ","SAME","PIN_BIT_SCALAR"),
-       8  => ("   ","SUM     ","SAME","PIN_BIT_SCALAR"),
-       9  => ("   ","VDD     ","SAME","PIN_BIT_SCALAR"),
-       10 => ("   ","VSS     ","SAME","PIN_BIT_SCALAR")
-       );
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --ATTRIBUTE PIN_BIT_INFORMATION of c_prism_csa42 : entity is
+  --  (
+  --    1  => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --    2  => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --    3  => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --    4  => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --    5  => ("   ","KI      ","SAME","PIN_BIT_SCALAR"),
+  --    6  => ("   ","KO      ","SAME","PIN_BIT_SCALAR"),
+  --    7  => ("   ","CAR     ","SAME","PIN_BIT_SCALAR"),
+  --    8  => ("   ","SUM     ","SAME","PIN_BIT_SCALAR"),
+  --    9  => ("   ","VDD     ","SAME","PIN_BIT_SCALAR"),
+  --    10 => ("   ","VSS     ","SAME","PIN_BIT_SCALAR")
+  --    );
 -- synopsys translate_on
 END                              c_prism_csa42;
 

--- a/rel/src/vhdl/ibm/std_ulogic_ao_support.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_ao_support.vhdl
@@ -38,7 +38,7 @@ package std_ulogic_ao_support is
   function gate_ao_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
-     gate1 : std_ulogic 
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -59,7 +59,7 @@ package std_ulogic_ao_support is
   function ao_2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -68,7 +68,7 @@ package std_ulogic_ao_support is
   function ao_2x1
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -89,7 +89,7 @@ package std_ulogic_ao_support is
   function gate_aoi_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -98,7 +98,7 @@ package std_ulogic_ao_support is
   function gate_aoi_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -119,7 +119,7 @@ package std_ulogic_ao_support is
   function aoi_2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -128,7 +128,7 @@ package std_ulogic_ao_support is
   function aoi_2x1
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -149,7 +149,7 @@ package std_ulogic_ao_support is
   function gate_oa_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -158,7 +158,7 @@ package std_ulogic_ao_support is
   function gate_oa_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -179,7 +179,7 @@ package std_ulogic_ao_support is
   function oa_2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -188,7 +188,7 @@ package std_ulogic_ao_support is
   function oa_2x1
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -209,7 +209,7 @@ package std_ulogic_ao_support is
   function gate_oai_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -218,7 +218,7 @@ package std_ulogic_ao_support is
   function gate_oai_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -239,7 +239,7 @@ package std_ulogic_ao_support is
   function oai_2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -248,7 +248,7 @@ package std_ulogic_ao_support is
   function oai_2x1
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -270,7 +270,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic  
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -280,7 +280,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic_vector  
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -303,7 +303,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -313,7 +313,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -336,7 +336,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic  
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -346,7 +346,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic_vector  
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -369,7 +369,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -379,7 +379,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -402,7 +402,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic  
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -412,7 +412,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic_vector  
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -435,7 +435,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -445,7 +445,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -468,7 +468,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic  
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -478,7 +478,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic_vector  
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -501,7 +501,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -511,7 +511,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -540,7 +540,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -550,7 +550,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -568,12 +568,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_2x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -583,7 +583,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -601,12 +601,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_2x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -616,7 +616,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -634,12 +634,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_2x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -649,7 +649,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -667,12 +667,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_2x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -682,7 +682,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -700,12 +700,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_2x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -715,7 +715,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -733,12 +733,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_2x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -748,7 +748,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -766,12 +766,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_2x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -781,7 +781,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -799,13 +799,13 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_2x2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -816,7 +816,7 @@ package std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -835,13 +835,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_2x2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -852,7 +852,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -871,13 +871,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_2x2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -888,7 +888,7 @@ package std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -907,13 +907,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_2x2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -924,7 +924,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -943,13 +943,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_2x2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -960,7 +960,7 @@ package std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -979,13 +979,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_2x2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -996,7 +996,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1015,13 +1015,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_2x2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1032,7 +1032,7 @@ package std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1051,13 +1051,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_2x2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1068,7 +1068,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1087,14 +1087,14 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_2x2x2
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic  
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1106,7 +1106,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic_vector  
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1126,14 +1126,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_2x2x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in2b  : std_ulogic  
+     in2b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1145,7 +1145,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in2b  : std_ulogic_vector  
+     in2b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1165,14 +1165,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_2x2x2
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic  
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1184,7 +1184,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic_vector  
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1204,14 +1204,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_2x2x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in2b  : std_ulogic  
+     in2b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1223,7 +1223,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in2b  : std_ulogic_vector  
+     in2b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1243,14 +1243,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_2x2x2
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic  
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1262,7 +1262,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic_vector  
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1282,14 +1282,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_2x2x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in2b  : std_ulogic  
+     in2b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1301,7 +1301,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in2b  : std_ulogic_vector  
+     in2b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1321,14 +1321,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_2x2x2
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic  
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1340,7 +1340,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic_vector  
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1360,14 +1360,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_2x2x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in2b  : std_ulogic  
+     in2b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1379,7 +1379,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in2b  : std_ulogic_vector  
+     in2b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1399,7 +1399,7 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   -- =============================================================
   -- 2x4 input Port AO/OA Gates
   -- =============================================================
@@ -1411,7 +1411,7 @@ package std_ulogic_ao_support is
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1422,7 +1422,7 @@ package std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1441,13 +1441,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_2x1x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1458,7 +1458,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1477,13 +1477,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_2x1x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1494,7 +1494,7 @@ package std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1513,13 +1513,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_2x1x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1530,7 +1530,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1549,13 +1549,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_2x1x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1566,7 +1566,7 @@ package std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1585,13 +1585,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_2x1x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1602,7 +1602,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1621,13 +1621,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_2x1x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1638,7 +1638,7 @@ package std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1657,13 +1657,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_2x1x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1674,7 +1674,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1693,14 +1693,14 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_2x2x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1712,7 +1712,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1732,14 +1732,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-   
+
   function ao_2x2x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1751,7 +1751,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1771,14 +1771,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_2x2x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1790,7 +1790,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1810,14 +1810,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_2x2x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1829,7 +1829,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1849,14 +1849,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_2x2x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1868,7 +1868,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1888,14 +1888,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_2x2x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1907,7 +1907,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1927,14 +1927,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_2x2x1x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1946,7 +1946,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1966,14 +1966,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_2x2x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -1985,7 +1985,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2005,7 +2005,7 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_2x2x2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
@@ -2013,7 +2013,7 @@ package std_ulogic_ao_support is
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2026,7 +2026,7 @@ package std_ulogic_ao_support is
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2047,7 +2047,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_2x2x2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -2055,7 +2055,7 @@ package std_ulogic_ao_support is
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2068,7 +2068,7 @@ package std_ulogic_ao_support is
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2089,7 +2089,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_2x2x2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
@@ -2097,7 +2097,7 @@ package std_ulogic_ao_support is
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2110,7 +2110,7 @@ package std_ulogic_ao_support is
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2131,7 +2131,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_2x2x2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -2139,7 +2139,7 @@ package std_ulogic_ao_support is
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2152,7 +2152,7 @@ package std_ulogic_ao_support is
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2173,7 +2173,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_2x2x2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
@@ -2181,7 +2181,7 @@ package std_ulogic_ao_support is
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2194,7 +2194,7 @@ package std_ulogic_ao_support is
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2215,7 +2215,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_2x2x2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -2223,7 +2223,7 @@ package std_ulogic_ao_support is
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2236,7 +2236,7 @@ package std_ulogic_ao_support is
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2257,7 +2257,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_2x2x2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
@@ -2265,7 +2265,7 @@ package std_ulogic_ao_support is
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2278,7 +2278,7 @@ package std_ulogic_ao_support is
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2299,7 +2299,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_2x2x2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -2307,7 +2307,7 @@ package std_ulogic_ao_support is
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2320,7 +2320,7 @@ package std_ulogic_ao_support is
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2341,7 +2341,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_2x2x2x2
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
@@ -2350,7 +2350,7 @@ package std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic  
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2364,7 +2364,7 @@ package std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic_vector  
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2386,7 +2386,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_2x2x2x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -2395,7 +2395,7 @@ package std_ulogic_ao_support is
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
      in3a  : std_ulogic ;
-     in3b  : std_ulogic  
+     in3b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2409,7 +2409,7 @@ package std_ulogic_ao_support is
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
      in3a  : std_ulogic_vector ;
-     in3b  : std_ulogic_vector  
+     in3b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2431,7 +2431,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_2x2x2x2
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
@@ -2440,7 +2440,7 @@ package std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic  
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2454,7 +2454,7 @@ package std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic_vector  
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2476,7 +2476,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_2x2x2x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -2485,7 +2485,7 @@ package std_ulogic_ao_support is
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
      in3a  : std_ulogic ;
-     in3b  : std_ulogic  
+     in3b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2499,7 +2499,7 @@ package std_ulogic_ao_support is
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
      in3a  : std_ulogic_vector ;
-     in3b  : std_ulogic_vector  
+     in3b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2521,7 +2521,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_2x2x2x2
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
@@ -2530,7 +2530,7 @@ package std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic  
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2544,7 +2544,7 @@ package std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic_vector  
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2566,7 +2566,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_2x2x2x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -2575,7 +2575,7 @@ package std_ulogic_ao_support is
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
      in3a  : std_ulogic ;
-     in3b  : std_ulogic  
+     in3b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2589,7 +2589,7 @@ package std_ulogic_ao_support is
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
      in3a  : std_ulogic_vector ;
-     in3b  : std_ulogic_vector  
+     in3b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2611,7 +2611,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_2x2x2x2
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
@@ -2620,7 +2620,7 @@ package std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic  
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2634,7 +2634,7 @@ package std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic_vector  
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2656,7 +2656,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_2x2x2x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -2665,7 +2665,7 @@ package std_ulogic_ao_support is
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
      in3a  : std_ulogic ;
-     in3b  : std_ulogic  
+     in3b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2679,7 +2679,7 @@ package std_ulogic_ao_support is
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
      in3a  : std_ulogic_vector ;
-     in3b  : std_ulogic_vector  
+     in3b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2701,7 +2701,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   -- =============================================================
   -- 3 input Port AO/OA Gates
   -- =============================================================
@@ -2712,7 +2712,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2722,7 +2722,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2740,12 +2740,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_3x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2755,7 +2755,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2773,12 +2773,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_3x1
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2788,7 +2788,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2806,12 +2806,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_3x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2821,7 +2821,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2839,12 +2839,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_3x1
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2854,7 +2854,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2872,12 +2872,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_3x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2887,7 +2887,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2905,12 +2905,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_3x1
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2920,7 +2920,7 @@ package std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2938,12 +2938,12 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_3x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2953,7 +2953,7 @@ package std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2971,13 +2971,13 @@ package std_ulogic_ao_support is
      6 => ("   ","PASS    ","    ","              "),
      7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_3x2
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -2988,7 +2988,7 @@ package std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3007,13 +3007,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_3x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3024,7 +3024,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3043,13 +3043,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_3x2
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3060,7 +3060,7 @@ package std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3079,13 +3079,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_3x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3096,7 +3096,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3115,13 +3115,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_3x2
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3132,7 +3132,7 @@ package std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3151,13 +3151,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_3x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3168,7 +3168,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3187,13 +3187,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_3x2
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3204,7 +3204,7 @@ package std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3223,13 +3223,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_3x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3240,7 +3240,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3259,14 +3259,14 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_3x3
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3278,7 +3278,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3298,14 +3298,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_3x3
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3317,7 +3317,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3337,14 +3337,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_3x3
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3356,7 +3356,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3376,14 +3376,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_3x3
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3395,7 +3395,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3415,14 +3415,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_3x3
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3434,7 +3434,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3454,14 +3454,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_3x3
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3473,7 +3473,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3493,14 +3493,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_3x3
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3512,7 +3512,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3532,14 +3532,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_3x3
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3551,7 +3551,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3571,7 +3571,7 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   -- =============================================================
   -- 4 input Port AO/OA Gates
   -- =============================================================
@@ -3583,7 +3583,7 @@ package std_ulogic_ao_support is
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3594,7 +3594,7 @@ package std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3613,13 +3613,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_4x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3630,7 +3630,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3649,13 +3649,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_4x1
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3666,7 +3666,7 @@ package std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3685,13 +3685,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_4x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3702,7 +3702,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3721,13 +3721,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_4x1
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3738,7 +3738,7 @@ package std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3757,13 +3757,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_4x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3774,7 +3774,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3793,13 +3793,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_4x1
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3810,7 +3810,7 @@ package std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3829,13 +3829,13 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_4x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3846,7 +3846,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3865,14 +3865,14 @@ package std_ulogic_ao_support is
      7 => ("   ","PASS    ","    ","              "),
      8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_4x2
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3884,7 +3884,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3904,14 +3904,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_4x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3923,7 +3923,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3943,14 +3943,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_4x2
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3962,7 +3962,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -3982,14 +3982,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_4x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4001,7 +4001,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4021,14 +4021,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_4x2
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4040,7 +4040,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4060,14 +4060,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_4x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4079,7 +4079,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4099,14 +4099,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_4x2
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4118,7 +4118,7 @@ package std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4138,14 +4138,14 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_4x2
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4157,7 +4157,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4177,7 +4177,7 @@ package std_ulogic_ao_support is
      8 => ("   ","PASS    ","    ","              "),
      9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_4x3
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
@@ -4185,7 +4185,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4198,7 +4198,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4219,7 +4219,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_4x3
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -4227,7 +4227,7 @@ package std_ulogic_ao_support is
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4240,7 +4240,7 @@ package std_ulogic_ao_support is
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4261,7 +4261,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_4x3
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
@@ -4269,7 +4269,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4282,7 +4282,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4303,7 +4303,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_4x3
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -4311,7 +4311,7 @@ package std_ulogic_ao_support is
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4324,7 +4324,7 @@ package std_ulogic_ao_support is
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4345,7 +4345,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_4x3
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
@@ -4353,7 +4353,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4366,7 +4366,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4387,7 +4387,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_4x3
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -4395,7 +4395,7 @@ package std_ulogic_ao_support is
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4408,7 +4408,7 @@ package std_ulogic_ao_support is
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4429,7 +4429,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_4x3
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
@@ -4437,7 +4437,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4450,7 +4450,7 @@ package std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4471,7 +4471,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_4x3
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -4479,7 +4479,7 @@ package std_ulogic_ao_support is
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4492,7 +4492,7 @@ package std_ulogic_ao_support is
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4513,7 +4513,7 @@ package std_ulogic_ao_support is
      9 => ("   ","PASS    ","    ","              "),
      10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_ao_4x4
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
@@ -4522,7 +4522,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4536,7 +4536,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4558,7 +4558,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function ao_4x4
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -4567,7 +4567,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in1c  : std_ulogic ;
-     in1d  : std_ulogic  
+     in1d  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4581,7 +4581,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in1c  : std_ulogic_vector ;
-     in1d  : std_ulogic_vector  
+     in1d  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4603,7 +4603,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_aoi_4x4
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
@@ -4612,7 +4612,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4626,7 +4626,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4648,7 +4648,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function aoi_4x4
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -4657,7 +4657,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in1c  : std_ulogic ;
-     in1d  : std_ulogic  
+     in1d  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4671,7 +4671,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in1c  : std_ulogic_vector ;
-     in1d  : std_ulogic_vector  
+     in1d  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4693,7 +4693,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oa_4x4
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
@@ -4702,7 +4702,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4716,7 +4716,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4738,7 +4738,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oa_4x4
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -4747,7 +4747,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in1c  : std_ulogic ;
-     in1d  : std_ulogic  
+     in1d  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4761,7 +4761,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in1c  : std_ulogic_vector ;
-     in1d  : std_ulogic_vector  
+     in1d  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4783,7 +4783,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function gate_oai_4x4
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
@@ -4792,7 +4792,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4806,7 +4806,7 @@ package std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4828,7 +4828,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
   function oai_4x4
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
@@ -4837,7 +4837,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in1c  : std_ulogic ;
-     in1d  : std_ulogic  
+     in1d  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4851,7 +4851,7 @@ package std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in1c  : std_ulogic_vector ;
-     in1d  : std_ulogic_vector  
+     in1d  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4873,7 +4873,7 @@ package std_ulogic_ao_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
-  
+
 end std_ulogic_ao_support;
 
 package body std_ulogic_ao_support is
@@ -4883,7 +4883,7 @@ package body std_ulogic_ao_support is
   function gate_ao_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4905,7 +4905,7 @@ package body std_ulogic_ao_support is
   function gate_ao_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4928,7 +4928,7 @@ package body std_ulogic_ao_support is
   function ao_2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4950,7 +4950,7 @@ package body std_ulogic_ao_support is
   function ao_2x1
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4972,7 +4972,7 @@ package body std_ulogic_ao_support is
   function gate_aoi_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -4994,7 +4994,7 @@ package body std_ulogic_ao_support is
   function gate_aoi_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5017,7 +5017,7 @@ package body std_ulogic_ao_support is
   function aoi_2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5039,7 +5039,7 @@ package body std_ulogic_ao_support is
   function aoi_2x1
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5061,7 +5061,7 @@ package body std_ulogic_ao_support is
   function gate_oa_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5083,7 +5083,7 @@ package body std_ulogic_ao_support is
   function gate_oa_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5106,7 +5106,7 @@ package body std_ulogic_ao_support is
   function oa_2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5128,7 +5128,7 @@ package body std_ulogic_ao_support is
   function oa_2x1
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5150,7 +5150,7 @@ package body std_ulogic_ao_support is
   function gate_oai_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5172,7 +5172,7 @@ package body std_ulogic_ao_support is
   function gate_oai_2x1
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5195,7 +5195,7 @@ package body std_ulogic_ao_support is
   function oai_2x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5217,7 +5217,7 @@ package body std_ulogic_ao_support is
   function oai_2x1
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5240,7 +5240,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic  
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5263,7 +5263,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic_vector  
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5287,7 +5287,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5310,7 +5310,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5333,7 +5333,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic  
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5356,7 +5356,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic_vector  
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5380,7 +5380,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5403,7 +5403,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5426,7 +5426,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic  
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5449,7 +5449,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic_vector  
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5473,7 +5473,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5496,7 +5496,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5519,7 +5519,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic  
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5542,7 +5542,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1   : std_ulogic_vector  
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5566,7 +5566,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5589,7 +5589,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5616,7 +5616,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5641,7 +5641,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5666,7 +5666,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5689,7 +5689,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5714,7 +5714,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5739,7 +5739,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5764,7 +5764,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5787,7 +5787,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5812,7 +5812,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5837,7 +5837,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5862,7 +5862,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5885,7 +5885,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5910,7 +5910,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5935,7 +5935,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5960,7 +5960,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -5983,7 +5983,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6009,7 +6009,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6035,7 +6035,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6061,7 +6061,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6087,7 +6087,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6113,7 +6113,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6139,7 +6139,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6165,7 +6165,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6191,7 +6191,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6217,7 +6217,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6243,7 +6243,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6269,7 +6269,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6295,7 +6295,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6321,7 +6321,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6347,7 +6347,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
-     gate2 : std_ulogic  
+     gate2 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6373,7 +6373,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in2a  : std_ulogic  
+     in2a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6399,7 +6399,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in2a  : std_ulogic_vector  
+     in2a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6426,7 +6426,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic  
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6453,7 +6453,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic_vector  
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6480,7 +6480,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in2b  : std_ulogic  
+     in2b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6507,7 +6507,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in2b  : std_ulogic_vector  
+     in2b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6534,7 +6534,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic  
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6561,7 +6561,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic_vector  
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6588,7 +6588,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in2b  : std_ulogic  
+     in2b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6615,7 +6615,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in2b  : std_ulogic_vector  
+     in2b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6642,7 +6642,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic  
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6669,7 +6669,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic_vector  
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6696,7 +6696,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in2b  : std_ulogic  
+     in2b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6723,7 +6723,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in2b  : std_ulogic_vector  
+     in2b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6750,7 +6750,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic  
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6777,7 +6777,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     in2   : std_ulogic_vector  
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6804,7 +6804,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in2b  : std_ulogic  
+     in2b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6831,7 +6831,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in2b  : std_ulogic_vector  
+     in2b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6861,7 +6861,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6888,7 +6888,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6909,13 +6909,13 @@ package body std_ulogic_ao_support is
 	      ( 0 to in0'length-1 => gate3 ) ;
     return result ;
   end gate_ao_2x1x1x1 ;
-  
+
   function ao_2x1x1x1
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6942,7 +6942,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6969,7 +6969,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -6996,7 +6996,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7023,7 +7023,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7050,7 +7050,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7077,7 +7077,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7104,7 +7104,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7131,7 +7131,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7158,7 +7158,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7185,7 +7185,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7212,7 +7212,7 @@ package body std_ulogic_ao_support is
      in0   : std_ulogic_vector ;
      gate1 : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7239,7 +7239,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in1a  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7266,7 +7266,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7294,7 +7294,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7322,7 +7322,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7350,7 +7350,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7378,7 +7378,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7406,7 +7406,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7434,7 +7434,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7462,7 +7462,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7490,7 +7490,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7518,7 +7518,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7546,7 +7546,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7574,7 +7574,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7602,7 +7602,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7630,7 +7630,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7658,7 +7658,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7686,7 +7686,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7714,7 +7714,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7743,7 +7743,7 @@ package body std_ulogic_ao_support is
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7772,7 +7772,7 @@ package body std_ulogic_ao_support is
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7801,7 +7801,7 @@ package body std_ulogic_ao_support is
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7830,7 +7830,7 @@ package body std_ulogic_ao_support is
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7859,7 +7859,7 @@ package body std_ulogic_ao_support is
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7888,7 +7888,7 @@ package body std_ulogic_ao_support is
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7917,7 +7917,7 @@ package body std_ulogic_ao_support is
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7946,7 +7946,7 @@ package body std_ulogic_ao_support is
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -7975,7 +7975,7 @@ package body std_ulogic_ao_support is
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8004,7 +8004,7 @@ package body std_ulogic_ao_support is
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8033,7 +8033,7 @@ package body std_ulogic_ao_support is
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8062,7 +8062,7 @@ package body std_ulogic_ao_support is
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8091,7 +8091,7 @@ package body std_ulogic_ao_support is
      in1   : std_ulogic ;
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8120,7 +8120,7 @@ package body std_ulogic_ao_support is
      in1   : std_ulogic_vector ;
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
-     gate3 : std_ulogic  
+     gate3 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8149,7 +8149,7 @@ package body std_ulogic_ao_support is
      in1b  : std_ulogic ;
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
-     in3a  : std_ulogic  
+     in3a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8178,7 +8178,7 @@ package body std_ulogic_ao_support is
      in1b  : std_ulogic_vector ;
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
-     in3a  : std_ulogic_vector  
+     in3a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8208,7 +8208,7 @@ package body std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic  
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8238,7 +8238,7 @@ package body std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic_vector  
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8268,7 +8268,7 @@ package body std_ulogic_ao_support is
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
      in3a  : std_ulogic ;
-     in3b  : std_ulogic  
+     in3b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8298,7 +8298,7 @@ package body std_ulogic_ao_support is
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
      in3a  : std_ulogic_vector ;
-     in3b  : std_ulogic_vector  
+     in3b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8328,7 +8328,7 @@ package body std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic  
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8358,7 +8358,7 @@ package body std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic_vector  
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8388,7 +8388,7 @@ package body std_ulogic_ao_support is
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
      in3a  : std_ulogic ;
-     in3b  : std_ulogic  
+     in3b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8418,7 +8418,7 @@ package body std_ulogic_ao_support is
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
      in3a  : std_ulogic_vector ;
-     in3b  : std_ulogic_vector  
+     in3b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8448,7 +8448,7 @@ package body std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic  
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8478,7 +8478,7 @@ package body std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic_vector  
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8508,7 +8508,7 @@ package body std_ulogic_ao_support is
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
      in3a  : std_ulogic ;
-     in3b  : std_ulogic  
+     in3b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8538,7 +8538,7 @@ package body std_ulogic_ao_support is
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
      in3a  : std_ulogic_vector ;
-     in3b  : std_ulogic_vector  
+     in3b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8568,7 +8568,7 @@ package body std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic  
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8598,7 +8598,7 @@ package body std_ulogic_ao_support is
      gate2 : std_ulogic ;
      in2   : std_ulogic_vector ;
      gate3 : std_ulogic ;
-     in3   : std_ulogic_vector  
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8628,7 +8628,7 @@ package body std_ulogic_ao_support is
      in2a  : std_ulogic ;
      in2b  : std_ulogic ;
      in3a  : std_ulogic ;
-     in3b  : std_ulogic  
+     in3b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8658,7 +8658,7 @@ package body std_ulogic_ao_support is
      in2a  : std_ulogic_vector ;
      in2b  : std_ulogic_vector ;
      in3a  : std_ulogic_vector ;
-     in3b  : std_ulogic_vector  
+     in3b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8688,7 +8688,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8712,7 +8712,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8736,7 +8736,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8760,7 +8760,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8784,7 +8784,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8808,7 +8808,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8832,7 +8832,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8856,7 +8856,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8880,7 +8880,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8904,7 +8904,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8928,7 +8928,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8952,7 +8952,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8976,7 +8976,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -8992,7 +8992,7 @@ package body std_ulogic_ao_support is
     variable result     : std_ulogic ;
   begin
     result := not( ( gate0 or in0a or in0b ) and
-		   ( gate1 ) ) ; 
+		   ( gate1 ) ) ;
     return result ;
   end gate_oai_3x1 ;
 
@@ -9000,7 +9000,7 @@ package body std_ulogic_ao_support is
     (gate0 : std_ulogic ;
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9016,7 +9016,7 @@ package body std_ulogic_ao_support is
     variable result     : std_ulogic_vector (0 to in0a'length-1);
   begin
     result := not( ( ( 0 to in0a'length-1 => gate0 ) or in0a or in0b ) and
-		   ( 0 to in0a'length-1 => gate1 ) ) ; 
+		   ( 0 to in0a'length-1 => gate1 ) ) ;
     return result ;
   end gate_oai_3x1 ;
 
@@ -9024,7 +9024,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9048,7 +9048,7 @@ package body std_ulogic_ao_support is
     (in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9073,7 +9073,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9098,7 +9098,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9123,7 +9123,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9148,7 +9148,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9173,7 +9173,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9198,7 +9198,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9223,7 +9223,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9248,7 +9248,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9273,7 +9273,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9298,7 +9298,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9323,7 +9323,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9348,7 +9348,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9373,7 +9373,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9398,7 +9398,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9423,7 +9423,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9448,7 +9448,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9474,7 +9474,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9500,7 +9500,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9526,7 +9526,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9552,7 +9552,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9578,7 +9578,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9604,7 +9604,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9630,7 +9630,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9656,7 +9656,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9682,7 +9682,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9708,7 +9708,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9734,7 +9734,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9760,7 +9760,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9786,7 +9786,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9812,7 +9812,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9838,7 +9838,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9864,7 +9864,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9893,7 +9893,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9918,7 +9918,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9943,7 +9943,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9968,7 +9968,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -9993,7 +9993,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10018,7 +10018,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10043,7 +10043,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10068,7 +10068,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10093,7 +10093,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10118,7 +10118,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10143,7 +10143,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10168,7 +10168,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10193,7 +10193,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic ;
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10218,7 +10218,7 @@ package body std_ulogic_ao_support is
      in0a  : std_ulogic_vector ;
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
-     gate1 : std_ulogic  
+     gate1 : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10243,7 +10243,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10268,7 +10268,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10294,7 +10294,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10320,7 +10320,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10346,7 +10346,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10372,7 +10372,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10398,7 +10398,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10424,7 +10424,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10450,7 +10450,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10476,7 +10476,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10502,7 +10502,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10528,7 +10528,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10554,7 +10554,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10580,7 +10580,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10606,7 +10606,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic ;
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic  
+     in1a  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10632,7 +10632,7 @@ package body std_ulogic_ao_support is
      in0b  : std_ulogic_vector ;
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
-     in1a  : std_ulogic_vector  
+     in1a  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10658,7 +10658,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10684,7 +10684,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10711,7 +10711,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10738,7 +10738,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10765,7 +10765,7 @@ package body std_ulogic_ao_support is
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10792,7 +10792,7 @@ package body std_ulogic_ao_support is
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10819,7 +10819,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10846,7 +10846,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10873,7 +10873,7 @@ package body std_ulogic_ao_support is
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10900,7 +10900,7 @@ package body std_ulogic_ao_support is
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10927,7 +10927,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10954,7 +10954,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -10981,7 +10981,7 @@ package body std_ulogic_ao_support is
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11008,7 +11008,7 @@ package body std_ulogic_ao_support is
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11035,7 +11035,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
-     in1b  : std_ulogic  
+     in1b  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11062,7 +11062,7 @@ package body std_ulogic_ao_support is
      in0c  : std_ulogic_vector ;
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
-     in1b  : std_ulogic_vector  
+     in1b  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11089,7 +11089,7 @@ package body std_ulogic_ao_support is
      in0d  : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11116,7 +11116,7 @@ package body std_ulogic_ao_support is
      in0d  : std_ulogic_vector ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11144,7 +11144,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11172,7 +11172,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11200,7 +11200,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in1c  : std_ulogic ;
-     in1d  : std_ulogic  
+     in1d  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11228,7 +11228,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in1c  : std_ulogic_vector ;
-     in1d  : std_ulogic_vector  
+     in1d  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11256,7 +11256,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11284,7 +11284,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11312,7 +11312,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in1c  : std_ulogic ;
-     in1d  : std_ulogic  
+     in1d  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11340,7 +11340,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in1c  : std_ulogic_vector ;
-     in1d  : std_ulogic_vector  
+     in1d  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11368,7 +11368,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11396,7 +11396,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11424,7 +11424,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in1c  : std_ulogic ;
-     in1d  : std_ulogic  
+     in1d  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11452,7 +11452,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in1c  : std_ulogic_vector ;
-     in1d  : std_ulogic_vector  
+     in1d  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11480,7 +11480,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
-     in1c  : std_ulogic  
+     in1c  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11508,7 +11508,7 @@ package body std_ulogic_ao_support is
      gate1 : std_ulogic ;
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
-     in1c  : std_ulogic_vector  
+     in1c  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11536,7 +11536,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic ;
      in1b  : std_ulogic ;
      in1c  : std_ulogic ;
-     in1d  : std_ulogic  
+     in1d  : std_ulogic
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""
@@ -11564,7 +11564,7 @@ package body std_ulogic_ao_support is
      in1a  : std_ulogic_vector ;
      in1b  : std_ulogic_vector ;
      in1c  : std_ulogic_vector ;
-     in1d  : std_ulogic_vector  
+     in1d  : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : string := ""
      ;blkdata : string := ""

--- a/rel/src/vhdl/ibm/std_ulogic_ao_support.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_ao_support.vhdl
@@ -47,13 +47,14 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_2x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_2x1 : function is true;
-  attribute pin_bit_information of gate_ao_2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_2x1
@@ -77,13 +78,14 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_2x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_2x1 : function is true;
-  attribute pin_bit_information of ao_2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_2x1
@@ -107,13 +109,14 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_2x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_2x1 : function is true;
-  attribute pin_bit_information of gate_aoi_2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_2x1
@@ -137,13 +140,14 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_2x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_2x1 : function is true;
-  attribute pin_bit_information of aoi_2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_2x1
@@ -167,13 +171,14 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_2x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_2x1 : function is true;
-  attribute pin_bit_information of gate_oa_2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_2x1
@@ -197,13 +202,14 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_2x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_2x1 : function is true;
-  attribute pin_bit_information of oa_2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_2x1
@@ -227,13 +233,14 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_2x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_2x1 : function is true;
-  attribute pin_bit_information of gate_oai_2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_2x1
@@ -257,13 +264,14 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_2x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_2x1 : function is true;
-  attribute pin_bit_information of oai_2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_2x2
@@ -289,14 +297,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_2x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_2x2 : function is true;
-  attribute pin_bit_information of gate_ao_2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_2x2
@@ -322,14 +331,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_2x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_2x2 : function is true;
-  attribute pin_bit_information of ao_2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_2x2
@@ -355,14 +365,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_2x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_2x2 : function is true;
-  attribute pin_bit_information of gate_aoi_2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_2x2
@@ -388,14 +399,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_2x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_2x2 : function is true;
-  attribute pin_bit_information of aoi_2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_2x2
@@ -421,14 +433,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_2x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_2x2 : function is true;
-  attribute pin_bit_information of gate_oa_2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_2x2
@@ -454,14 +467,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_2x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_2x2 : function is true;
-  attribute pin_bit_information of oa_2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_2x2
@@ -487,14 +501,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_2x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_2x2 : function is true;
-  attribute pin_bit_information of gate_oai_2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_2x2
@@ -520,14 +535,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_2x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_2x2 : function is true;
-  attribute pin_bit_information of oai_2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   -- =============================================================
@@ -559,14 +575,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_2x1x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_2x1x1 : function is true;
-  attribute pin_bit_information of gate_ao_2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_2x1x1
@@ -592,14 +609,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_2x1x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_2x1x1 : function is true;
-  attribute pin_bit_information of ao_2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_2x1x1
@@ -625,14 +643,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_2x1x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_2x1x1 : function is true;
-  attribute pin_bit_information of gate_aoi_2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_2x1x1
@@ -658,14 +677,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_2x1x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_2x1x1 : function is true;
-  attribute pin_bit_information of aoi_2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_2x1x1
@@ -691,14 +711,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_2x1x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_2x1x1 : function is true;
-  attribute pin_bit_information of gate_oa_2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_2x1x1
@@ -724,14 +745,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_2x1x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_2x1x1 : function is true;
-  attribute pin_bit_information of oa_2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_2x1x1
@@ -757,14 +779,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_2x1x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_2x1x1 : function is true;
-  attribute pin_bit_information of gate_oai_2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_2x1x1
@@ -790,14 +813,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_2x1x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_2x1x1 : function is true;
-  attribute pin_bit_information of oai_2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_2x2x1
@@ -825,15 +849,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_2x2x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_2x2x1 : function is true;
-  attribute pin_bit_information of gate_ao_2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_2x2x1
@@ -861,15 +886,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_2x2x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_2x2x1 : function is true;
-  attribute pin_bit_information of ao_2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_2x2x1
@@ -897,15 +923,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_2x2x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_2x2x1 : function is true;
-  attribute pin_bit_information of gate_aoi_2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_2x2x1
@@ -933,15 +960,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_2x2x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_2x2x1 : function is true;
-  attribute pin_bit_information of aoi_2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_2x2x1
@@ -969,15 +997,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_2x2x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_2x2x1 : function is true;
-  attribute pin_bit_information of gate_oa_2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_2x2x1
@@ -1005,15 +1034,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_2x2x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_2x2x1 : function is true;
-  attribute pin_bit_information of oa_2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_2x2x1
@@ -1041,15 +1071,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_2x2x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_2x2x1 : function is true;
-  attribute pin_bit_information of gate_oai_2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_2x2x1
@@ -1077,15 +1108,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_2x2x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_2x2x1 : function is true;
-  attribute pin_bit_information of oai_2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_2x2x2
@@ -1115,16 +1147,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_2x2x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_2x2x2 : function is true;
-  attribute pin_bit_information of gate_ao_2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_2x2x2
@@ -1154,16 +1187,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_2x2x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_2x2x2 : function is true;
-  attribute pin_bit_information of ao_2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_2x2x2
@@ -1193,16 +1227,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_2x2x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_2x2x2 : function is true;
-  attribute pin_bit_information of gate_aoi_2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_2x2x2
@@ -1232,16 +1267,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_2x2x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_2x2x2 : function is true;
-  attribute pin_bit_information of aoi_2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_2x2x2
@@ -1271,16 +1307,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_2x2x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_2x2x2 : function is true;
-  attribute pin_bit_information of gate_oa_2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_2x2x2
@@ -1310,16 +1347,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_2x2x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_2x2x2 : function is true;
-  attribute pin_bit_information of oa_2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_2x2x2
@@ -1349,16 +1387,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_2x2x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_2x2x2 : function is true;
-  attribute pin_bit_information of gate_oai_2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_2x2x2
@@ -1388,16 +1427,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_2x2x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_2x2x2 : function is true;
-  attribute pin_bit_information of oai_2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   -- =============================================================
@@ -1431,15 +1471,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_2x1x1x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_2x1x1x1 : function is true;
-  attribute pin_bit_information of gate_ao_2x1x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_2x1x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_2x1x1x1
@@ -1467,15 +1508,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_2x1x1x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_2x1x1x1 : function is true;
-  attribute pin_bit_information of ao_2x1x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_2x1x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_2x1x1x1
@@ -1503,15 +1545,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_2x1x1x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_2x1x1x1 : function is true;
-  attribute pin_bit_information of gate_aoi_2x1x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_2x1x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_2x1x1x1
@@ -1539,15 +1582,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_2x1x1x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_2x1x1x1 : function is true;
-  attribute pin_bit_information of aoi_2x1x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_2x1x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_2x1x1x1
@@ -1575,15 +1619,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_2x1x1x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_2x1x1x1 : function is true;
-  attribute pin_bit_information of gate_oa_2x1x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_2x1x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_2x1x1x1
@@ -1611,15 +1656,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_2x1x1x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_2x1x1x1 : function is true;
-  attribute pin_bit_information of oa_2x1x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_2x1x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_2x1x1x1
@@ -1647,15 +1693,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_2x1x1x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_2x1x1x1 : function is true;
-  attribute pin_bit_information of gate_oai_2x1x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_2x1x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_2x1x1x1
@@ -1683,15 +1730,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_2x1x1x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_2x1x1x1 : function is true;
-  attribute pin_bit_information of oai_2x1x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_2x1x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_2x2x1x1
@@ -1721,16 +1769,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_2x2x1x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_2x2x1x1 : function is true;
-  attribute pin_bit_information of gate_ao_2x2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_2x2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_2x2x1x1
@@ -1760,16 +1809,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_2x2x1x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_2x2x1x1 : function is true;
-  attribute pin_bit_information of ao_2x2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_2x2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_2x2x1x1
@@ -1799,16 +1849,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_2x2x1x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_2x2x1x1 : function is true;
-  attribute pin_bit_information of gate_aoi_2x2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_2x2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_2x2x1x1
@@ -1838,16 +1889,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_2x2x1x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_2x2x1x1 : function is true;
-  attribute pin_bit_information of aoi_2x2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_2x2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_2x2x1x1
@@ -1877,16 +1929,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_2x2x1x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_2x2x1x1 : function is true;
-  attribute pin_bit_information of gate_oa_2x2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_2x2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_2x2x1x1
@@ -1916,16 +1969,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_2x2x1x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_2x2x1x1 : function is true;
-  attribute pin_bit_information of oa_2x2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_2x2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_2x2x1x1
@@ -1955,16 +2009,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_2x2x1x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_2x2x1x1 : function is true;
-  attribute pin_bit_information of gate_oai_2x2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_2x2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_2x2x1x1
@@ -1994,16 +2049,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_2x2x1x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_2x2x1x1 : function is true;
-  attribute pin_bit_information of oai_2x2x1x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_2x2x1x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_2x2x2x1
@@ -2035,17 +2091,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_2x2x2x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_2x2x2x1 : function is true;
-  attribute pin_bit_information of gate_ao_2x2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_2x2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_2x2x2x1
@@ -2077,17 +2134,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_2x2x2x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_2x2x2x1 : function is true;
-  attribute pin_bit_information of ao_2x2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_2x2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_2x2x2x1
@@ -2119,17 +2177,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_2x2x2x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_2x2x2x1 : function is true;
-  attribute pin_bit_information of gate_aoi_2x2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_2x2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_2x2x2x1
@@ -2161,17 +2220,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_2x2x2x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_2x2x2x1 : function is true;
-  attribute pin_bit_information of aoi_2x2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_2x2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_2x2x2x1
@@ -2203,17 +2263,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_2x2x2x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_2x2x2x1 : function is true;
-  attribute pin_bit_information of gate_oa_2x2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_2x2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_2x2x2x1
@@ -2245,17 +2306,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_2x2x2x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_2x2x2x1 : function is true;
-  attribute pin_bit_information of oa_2x2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_2x2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_2x2x2x1
@@ -2287,17 +2349,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_2x2x2x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_2x2x2x1 : function is true;
-  attribute pin_bit_information of gate_oai_2x2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_2x2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_2x2x2x1
@@ -2329,17 +2392,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_2x2x2x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_2x2x2x1 : function is true;
-  attribute pin_bit_information of oai_2x2x2x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_2x2x2x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_2x2x2x2
@@ -2373,18 +2437,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_2x2x2x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_2x2x2x2 : function is true;
-  attribute pin_bit_information of gate_ao_2x2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_2x2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_2x2x2x2
@@ -2418,18 +2483,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_2x2x2x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_2x2x2x2 : function is true;
-  attribute pin_bit_information of ao_2x2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_2x2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_2x2x2x2
@@ -2463,18 +2529,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_2x2x2x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_2x2x2x2 : function is true;
-  attribute pin_bit_information of gate_aoi_2x2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_2x2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_2x2x2x2
@@ -2508,18 +2575,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_2x2x2x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_2x2x2x2 : function is true;
-  attribute pin_bit_information of aoi_2x2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_2x2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_2x2x2x2
@@ -2553,18 +2621,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_2x2x2x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_2x2x2x2 : function is true;
-  attribute pin_bit_information of gate_oa_2x2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_2x2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_2x2x2x2
@@ -2598,18 +2667,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_2x2x2x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_2x2x2x2 : function is true;
-  attribute pin_bit_information of oa_2x2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_2x2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_2x2x2x2
@@ -2643,18 +2713,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_2x2x2x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_2x2x2x2 : function is true;
-  attribute pin_bit_information of gate_oai_2x2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_2x2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_2x2x2x2
@@ -2688,18 +2759,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_2x2x2x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_2x2x2x2 : function is true;
-  attribute pin_bit_information of oai_2x2x2x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_2x2x2x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","C       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","D       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   -- =============================================================
@@ -2731,14 +2803,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_3x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_3x1 : function is true;
-  attribute pin_bit_information of gate_ao_3x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_3x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_3x1
@@ -2764,14 +2837,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_3x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_3x1 : function is true;
-  attribute pin_bit_information of ao_3x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_3x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_3x1
@@ -2797,14 +2871,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_3x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_3x1 : function is true;
-  attribute pin_bit_information of gate_aoi_3x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_3x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_3x1
@@ -2830,14 +2905,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_3x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_3x1 : function is true;
-  attribute pin_bit_information of aoi_3x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_3x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_3x1
@@ -2863,14 +2939,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_3x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_3x1 : function is true;
-  attribute pin_bit_information of gate_oa_3x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_3x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_3x1
@@ -2896,14 +2973,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_3x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_3x1 : function is true;
-  attribute pin_bit_information of oa_3x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_3x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_3x1
@@ -2929,14 +3007,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_3x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_3x1 : function is true;
-  attribute pin_bit_information of gate_oai_3x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_3x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_3x1
@@ -2962,14 +3041,15 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_3x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_3x1 : function is true;
-  attribute pin_bit_information of oai_3x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_3x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_3x2
@@ -2997,15 +3077,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_3x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_3x2 : function is true;
-  attribute pin_bit_information of gate_ao_3x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_3x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_3x2
@@ -3033,15 +3114,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_3x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_3x2 : function is true;
-  attribute pin_bit_information of ao_3x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_3x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_3x2
@@ -3069,15 +3151,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_3x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_3x2 : function is true;
-  attribute pin_bit_information of gate_aoi_3x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_3x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_3x2
@@ -3105,15 +3188,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_3x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_3x2 : function is true;
-  attribute pin_bit_information of aoi_3x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_3x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_3x2
@@ -3141,15 +3225,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_3x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_3x2 : function is true;
-  attribute pin_bit_information of gate_oa_3x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_3x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_3x2
@@ -3177,15 +3262,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_3x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_3x2 : function is true;
-  attribute pin_bit_information of oa_3x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_3x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_3x2
@@ -3213,15 +3299,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_3x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_3x2 : function is true;
-  attribute pin_bit_information of gate_oai_3x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_3x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_3x2
@@ -3249,15 +3336,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_3x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_3x2 : function is true;
-  attribute pin_bit_information of oai_3x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_3x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_3x3
@@ -3287,16 +3375,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_3x3 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_3x3 : function is true;
-  attribute pin_bit_information of gate_ao_3x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_3x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_3x3
@@ -3326,16 +3415,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_3x3 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_3x3 : function is true;
-  attribute pin_bit_information of ao_3x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_3x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_3x3
@@ -3365,16 +3455,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_3x3 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_3x3 : function is true;
-  attribute pin_bit_information of gate_aoi_3x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_3x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_3x3
@@ -3404,16 +3495,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_3x3 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_3x3 : function is true;
-  attribute pin_bit_information of aoi_3x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_3x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_3x3
@@ -3443,16 +3535,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_3x3 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_3x3 : function is true;
-  attribute pin_bit_information of gate_oa_3x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_3x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_3x3
@@ -3482,16 +3575,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_3x3 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_3x3 : function is true;
-  attribute pin_bit_information of oa_3x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_3x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_3x3
@@ -3521,16 +3615,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_3x3 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_3x3 : function is true;
-  attribute pin_bit_information of gate_oai_3x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_3x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_3x3
@@ -3560,16 +3655,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_3x3 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_3x3 : function is true;
-  attribute pin_bit_information of oai_3x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_3x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   -- =============================================================
@@ -3603,15 +3699,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_4x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_4x1 : function is true;
-  attribute pin_bit_information of gate_ao_4x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_4x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_4x1
@@ -3639,15 +3736,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_4x1 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_4x1 : function is true;
-  attribute pin_bit_information of ao_4x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_4x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_4x1
@@ -3675,15 +3773,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_4x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_4x1 : function is true;
-  attribute pin_bit_information of gate_aoi_4x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_4x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_4x1
@@ -3711,15 +3810,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_4x1 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_4x1 : function is true;
-  attribute pin_bit_information of aoi_4x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_4x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_4x1
@@ -3747,15 +3847,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_4x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_4x1 : function is true;
-  attribute pin_bit_information of gate_oa_4x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_4x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_4x1
@@ -3783,15 +3884,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_4x1 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_4x1 : function is true;
-  attribute pin_bit_information of oa_4x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_4x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_4x1
@@ -3819,15 +3921,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_4x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_4x1 : function is true;
-  attribute pin_bit_information of gate_oai_4x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_4x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_4x1
@@ -3855,15 +3958,16 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_4x1 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_4x1 : function is true;
-  attribute pin_bit_information of oai_4x1 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_4x1 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_4x2
@@ -3893,16 +3997,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_4x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_4x2 : function is true;
-  attribute pin_bit_information of gate_ao_4x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_4x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_4x2
@@ -3932,16 +4037,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_4x2 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_4x2 : function is true;
-  attribute pin_bit_information of ao_4x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_4x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_4x2
@@ -3971,16 +4077,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_4x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_4x2 : function is true;
-  attribute pin_bit_information of gate_aoi_4x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_4x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_4x2
@@ -4010,16 +4117,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_4x2 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_4x2 : function is true;
-  attribute pin_bit_information of aoi_4x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_4x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_4x2
@@ -4049,16 +4157,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_4x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_4x2 : function is true;
-  attribute pin_bit_information of gate_oa_4x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_4x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_4x2
@@ -4088,16 +4197,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_4x2 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_4x2 : function is true;
-  attribute pin_bit_information of oa_4x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_4x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_4x2
@@ -4127,16 +4237,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_4x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_4x2 : function is true;
-  attribute pin_bit_information of gate_oai_4x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_4x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_4x2
@@ -4166,16 +4277,17 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_4x2 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_4x2 : function is true;
-  attribute pin_bit_information of oai_4x2 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_4x2 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_4x3
@@ -4207,17 +4319,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_4x3 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_4x3 : function is true;
-  attribute pin_bit_information of gate_ao_4x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_4x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_4x3
@@ -4249,17 +4362,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_4x3 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_4x3 : function is true;
-  attribute pin_bit_information of ao_4x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_4x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_4x3
@@ -4291,17 +4405,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_4x3 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_4x3 : function is true;
-  attribute pin_bit_information of gate_aoi_4x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_4x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_4x3
@@ -4333,17 +4448,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_4x3 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_4x3 : function is true;
-  attribute pin_bit_information of aoi_4x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_4x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_4x3
@@ -4375,17 +4491,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_4x3 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_4x3 : function is true;
-  attribute pin_bit_information of gate_oa_4x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_4x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_4x3
@@ -4417,17 +4534,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_4x3 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_4x3 : function is true;
-  attribute pin_bit_information of oa_4x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_4x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_4x3
@@ -4459,17 +4577,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_4x3 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_4x3 : function is true;
-  attribute pin_bit_information of gate_oai_4x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_4x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_4x3
@@ -4501,17 +4620,18 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_4x3 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_4x3 : function is true;
-  attribute pin_bit_information of oai_4x3 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_4x3 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_ao_4x4
@@ -4545,18 +4665,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_ao_4x4 : function is "VHDL-AO" ;
   attribute recursive_synthesis of gate_ao_4x4 : function is true;
-  attribute pin_bit_information of gate_ao_4x4 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_ao_4x4 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function ao_4x4
@@ -4590,18 +4711,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of ao_4x4 : function is "VHDL-AO" ;
   attribute recursive_synthesis of ao_4x4 : function is true;
-  attribute pin_bit_information of ao_4x4 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of ao_4x4 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_aoi_4x4
@@ -4635,18 +4757,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_aoi_4x4 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of gate_aoi_4x4 : function is true;
-  attribute pin_bit_information of gate_aoi_4x4 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_aoi_4x4 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function aoi_4x4
@@ -4680,18 +4803,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of aoi_4x4 : function is "VHDL-AOI" ;
   attribute recursive_synthesis of aoi_4x4 : function is true;
-  attribute pin_bit_information of aoi_4x4 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of aoi_4x4 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oa_4x4
@@ -4725,18 +4849,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oa_4x4 : function is "VHDL-OA" ;
   attribute recursive_synthesis of gate_oa_4x4 : function is true;
-  attribute pin_bit_information of gate_oa_4x4 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oa_4x4 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oa_4x4
@@ -4770,18 +4895,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oa_4x4 : function is "VHDL-OA" ;
   attribute recursive_synthesis of oa_4x4 : function is true;
-  attribute pin_bit_information of oa_4x4 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oa_4x4 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function gate_oai_4x4
@@ -4815,18 +4941,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of gate_oai_4x4 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of gate_oai_4x4 : function is true;
-  attribute pin_bit_information of gate_oai_4x4 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_oai_4x4 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function oai_4x4
@@ -4860,18 +4987,19 @@ package std_ulogic_ao_support is
   -- synopsys translate_off
   attribute btr_name   of oai_4x4 : function is "VHDL-OAI" ;
   attribute recursive_synthesis of oai_4x4 : function is true;
-  attribute pin_bit_information of oai_4x4 : function is
-    (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of oai_4x4 : function is
+  --  (1 => ("   ","A       ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","A       ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","B       ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","B       ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
 end std_ulogic_ao_support;

--- a/rel/src/vhdl/ibm/std_ulogic_function_support.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_function_support.vhdl
@@ -78,10 +78,11 @@ package std_ulogic_function_support is
   -- Synopsys translate_off
   attribute btr_name            of gate : function is "AND" ;
   attribute recursive_synthesis of gate : function is true ;
-  attribute pin_bit_information of gate : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     3 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   3 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   --  Dot Functions
@@ -91,9 +92,10 @@ package std_ulogic_function_support is
   -- Synopsys translate_off
   attribute btr_name            of dot_and : function is "VHDL-DOTA" ;
   attribute recursive_synthesis of dot_and : function is true ;
-  attribute pin_bit_information of dot_and : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of dot_and : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function dot_or
@@ -102,9 +104,10 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of dot_or     : function is "VHDL-DOTO" ;
   attribute recursive_synthesis of dot_or     : function is true ;
-  attribute pin_bit_information of dot_or     : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of dot_or     : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function clock_tree_dot
@@ -117,9 +120,10 @@ package std_ulogic_function_support is
   -- Synopsys translate_off
   attribute btr_name            of clock_tree_dot : function is "VHDL-CDOT" ;
   attribute recursive_synthesis of clock_tree_dot : function is true ;
-  attribute pin_bit_information of clock_tree_dot : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of clock_tree_dot : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   --  Generic Terminator
@@ -141,10 +145,11 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of terminator : procedure is "TERMINATOR";
   attribute recursive_synthesis of terminator : procedure is true ;
-  attribute pin_bit_information of terminator : procedure is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of terminator : procedure is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "));
   -- Synopsys translate_on
 
   --  Generic Delay
@@ -170,11 +175,12 @@ package std_ulogic_function_support is
   attribute recursive_synthesis of delay : function is true ;
   attribute block_data          of delay : function is
     "SUB_FUNC=/DELAY/LOGIC_STYLE=/DIRECT/" ;
-  attribute pin_bit_information of delay : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of delay : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   --  Generic Buffer
@@ -200,11 +206,12 @@ package std_ulogic_function_support is
   attribute recursive_synthesis of buff : function is true ;
   attribute block_data          of buff  : function is
     "LOGIC_STYLE=/DIRECT/" ;
-  attribute pin_bit_information of buff : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of buff : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   -- Invert single bit
@@ -228,11 +235,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of invert : function is "NOT" ;
   attribute recursive_synthesis of invert : function is true ;
-  attribute pin_bit_information of invert : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of invert : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   -- Compare single bit
@@ -258,12 +266,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of compare : function is "VHDL-COMPARE" ;
   attribute recursive_synthesis of compare : function is true ;
-  attribute pin_bit_information of compare : function is
-    (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
-     2 => ("   ","M0      ","INCR","PIN_BIT_SCALAR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","EQ      ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of compare : function is
+  --  (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","M0      ","INCR","PIN_BIT_SCALAR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","EQ      ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   --  Parity Functions
@@ -279,11 +288,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of parity : function is "XOR" ;
   attribute recursive_synthesis of parity : function is true ;
-  attribute pin_bit_information of parity : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of parity : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
   function parity_map
     (in0   : std_ulogic_vector
@@ -299,11 +309,12 @@ package std_ulogic_function_support is
   attribute recursive_synthesis of parity_map : function is true ;
   attribute block_data          of parity_map : function is
     "LOGIC_STYLE=/DIRECT/" ;
-  attribute pin_bit_information of parity_map : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of parity_map : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   -- Parity gneration/checking functions
@@ -319,11 +330,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name          of parity_gen_odd : function is "XNOR" ;
   attribute recursive_synthesis of parity_gen_odd : function is true;
-  attribute pin_bit_information of parity_gen_odd : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of parity_gen_odd : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function parity_gen_even
@@ -337,11 +349,12 @@ package std_ulogic_function_support is
   -- Synopsys translate_off
   attribute btr_name          of parity_gen_even : function is "XOR" ;
   attribute recursive_synthesis of parity_gen_even : function is true;
-  attribute pin_bit_information of parity_gen_even : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of parity_gen_even : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function is_parity_odd
@@ -355,11 +368,12 @@ package std_ulogic_function_support is
   -- Synopsys translate_off
   attribute btr_name          of is_parity_odd : function is "XOR" ;
   attribute recursive_synthesis of is_parity_odd : function is true;
-  attribute pin_bit_information of is_parity_odd : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of is_parity_odd : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function is_parity_even
@@ -373,11 +387,12 @@ package std_ulogic_function_support is
   -- Synopsys translate_off
   attribute btr_name          of is_parity_even : function is "XNOR" ;
   attribute recursive_synthesis of is_parity_even : function is true;
-  attribute pin_bit_information of is_parity_even : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of is_parity_even : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   --  Full Adder
@@ -406,14 +421,15 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of full_add : procedure is "VHDL-FA";
   attribute recursive_synthesis of full_add : procedure is true ;
-  attribute pin_bit_information of full_add : procedure is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","CIN     ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","SUM     ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","COUT    ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of full_add : procedure is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","CIN     ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","SUM     ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","COUT    ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "));
   -- Synopsys translate_on
 
   --  Ripple Adder function
@@ -441,10 +457,11 @@ package std_ulogic_function_support is
   attribute recursive_synthesis of tie_0 : function is true ;
   attribute block_data          of tie_0 : function is
     "LOGIC_STYLE=/DIRECT/" ;
-  attribute pin_bit_information of tie_0 : function is
-    (1 => ("   ","PASS    ","    ","              "),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","ZERO    ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of tie_0 : function is
+  --  (1 => ("   ","PASS    ","    ","              "),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","ZERO    ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function vector_tie_0
@@ -460,11 +477,12 @@ package std_ulogic_function_support is
   attribute recursive_synthesis of vector_tie_0 : function is true ;
   attribute block_data          of vector_tie_0 : function is
     "LOGIC_STYLE=/DIRECT/" ;
-  attribute pin_bit_information of vector_tie_0 : function is
-    (1 => ("   ","IGNR    ","    ","              "),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","ZERO    ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of vector_tie_0 : function is
+  --  (1 => ("   ","IGNR    ","    ","              "),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","ZERO    ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function tie_1
@@ -479,10 +497,11 @@ package std_ulogic_function_support is
   attribute recursive_synthesis of tie_1    : function is true ;
   attribute block_data          of tie_1    : function is
     "LOGIC_STYLE=/DIRECT/" ;
-  attribute pin_bit_information of tie_1 : function is
-    (1 => ("   ","PASS    ","    ","              "),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","ONE     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of tie_1 : function is
+  --  (1 => ("   ","PASS    ","    ","              "),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","ONE     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function vector_tie_1
@@ -498,11 +517,12 @@ package std_ulogic_function_support is
   attribute recursive_synthesis of vector_tie_1 : function is true ;
   attribute block_data          of vector_tie_1 : function is
     "LOGIC_STYLE=/DIRECT/" ;
-  attribute pin_bit_information of vector_tie_1 : function is
-    (1 => ("   ","IGNR    ","    ","              "),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","ONE     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of vector_tie_1 : function is
+  --  (1 => ("   ","IGNR    ","    ","              "),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","ONE     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function reverse
@@ -520,11 +540,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of and_reduce : function is "AND" ;
   attribute recursive_synthesis of and_reduce : function is true ;
-  attribute pin_bit_information of and_reduce : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of and_reduce : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function or_reduce
@@ -538,11 +559,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of or_reduce : function is "OR" ;
   attribute recursive_synthesis of or_reduce : function is true ;
-  attribute pin_bit_information of or_reduce : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of or_reduce : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function nand_reduce
@@ -556,11 +578,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nand_reduce : function is "NAND" ;
   attribute recursive_synthesis of nand_reduce : function is true ;
-  attribute pin_bit_information of nand_reduce : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nand_reduce : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function nor_reduce
@@ -574,11 +597,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nor_reduce : function is "NOR" ;
   attribute recursive_synthesis of nor_reduce : function is true ;
-  attribute pin_bit_information of nor_reduce : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nor_reduce : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function xor_reduce
@@ -592,11 +616,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of xor_reduce : function is "XOR" ;
   attribute recursive_synthesis of xor_reduce : function is true ;
-  attribute pin_bit_information of xor_reduce : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of xor_reduce : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function xnor_reduce
@@ -610,11 +635,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of xnor_reduce : function is "XNOR" ;
   attribute recursive_synthesis of xnor_reduce : function is true ;
-  attribute pin_bit_information of xnor_reduce : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of xnor_reduce : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   -- Vector of gating bits gating a single vector of data bits
@@ -648,12 +674,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of gate_and : function is "AND" ;
   attribute recursive_synthesis of gate_and : function is true ;
-  attribute pin_bit_information of gate_and : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_and : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function gate_or
@@ -686,12 +713,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of gate_or : function is "OR" ;
   attribute recursive_synthesis of gate_or : function is true ;
-  attribute pin_bit_information of gate_or : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_or : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function gate_nand
@@ -724,12 +752,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of gate_nand : function is "NAND" ;
   attribute recursive_synthesis of gate_nand : function is true ;
-  attribute pin_bit_information of gate_nand : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_nand : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function gate_nor
@@ -762,12 +791,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of gate_nor : function is "NOR" ;
   attribute recursive_synthesis of gate_nor : function is true ;
-  attribute pin_bit_information of gate_nor : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_nor : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function gate_xor
@@ -791,12 +821,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of gate_xor : function is "XOR" ;
   attribute recursive_synthesis of gate_xor : function is true ;
-  attribute pin_bit_information of gate_xor : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_xor : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function gate_xnor
@@ -820,12 +851,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of gate_xnor : function is "XNOR" ;
   attribute recursive_synthesis of gate_xnor : function is true ;
-  attribute pin_bit_information of gate_xnor : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of gate_xnor : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   -- Vectored primitive <gate> 2 input functions
@@ -852,12 +884,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of and_2 : function is "AND" ;
   attribute recursive_synthesis of and_2 : function is true ;
-  attribute pin_bit_information of and_2 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of and_2 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function or_2
@@ -881,12 +914,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of or_2 : function is "OR" ;
   attribute recursive_synthesis of or_2 : function is true ;
-  attribute pin_bit_information of or_2 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of or_2 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nand_2
@@ -910,12 +944,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nand_2 : function is "NAND" ;
   attribute recursive_synthesis of nand_2 : function is true ;
-  attribute pin_bit_information of nand_2 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nand_2 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nor_2
@@ -939,12 +974,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nor_2 : function is "NOR" ;
   attribute recursive_synthesis of nor_2 : function is true ;
-  attribute pin_bit_information of nor_2 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nor_2 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function xor_2
@@ -968,12 +1004,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of xor_2 : function is "XOR" ;
   attribute recursive_synthesis of xor_2 : function is true ;
-  attribute pin_bit_information of xor_2 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of xor_2 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function xnor_2
@@ -997,12 +1034,13 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of xnor_2 : function is "XNOR" ;
   attribute recursive_synthesis of xnor_2 : function is true ;
-  attribute pin_bit_information of xnor_2 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of xnor_2 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   -- Vectored primitive <gate> 3 input functions
@@ -1031,13 +1069,14 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of and_3 : function is "AND" ;
   attribute recursive_synthesis of and_3 : function is true ;
-  attribute pin_bit_information of and_3 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of and_3 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function or_3
@@ -1063,13 +1102,14 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of or_3 : function is "OR" ;
   attribute recursive_synthesis of or_3 : function is true ;
-  attribute pin_bit_information of or_3 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of or_3 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nand_3
@@ -1095,13 +1135,14 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nand_3 : function is "NAND" ;
   attribute recursive_synthesis of nand_3 : function is true ;
-  attribute pin_bit_information of nand_3 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nand_3 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nor_3
@@ -1127,13 +1168,14 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nor_3 : function is "NOR" ;
   attribute recursive_synthesis of nor_3 : function is true ;
-  attribute pin_bit_information of nor_3 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nor_3 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function xor_3
@@ -1159,13 +1201,14 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of xor_3 : function is "XOR" ;
   attribute recursive_synthesis of xor_3 : function is true ;
-  attribute pin_bit_information of xor_3 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of xor_3 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function xnor_3
@@ -1191,13 +1234,14 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of xnor_3 : function is "XNOR" ;
   attribute recursive_synthesis of xnor_3 : function is true ;
-  attribute pin_bit_information of xnor_3 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of xnor_3 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   -- Vectored primitive <gate> 4 input functions
@@ -1227,14 +1271,15 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of and_4 : function is "AND" ;
   attribute recursive_synthesis of and_4 : function is true ;
-  attribute pin_bit_information of and_4 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of and_4 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function or_4
@@ -1262,14 +1307,15 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of or_4 : function is "OR" ;
   attribute recursive_synthesis of or_4 : function is true ;
-  attribute pin_bit_information of or_4 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of or_4 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nand_4
@@ -1297,14 +1343,15 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nand_4 : function is "NAND" ;
   attribute recursive_synthesis of nand_4 : function is true ;
-  attribute pin_bit_information of nand_4 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nand_4 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nor_4
@@ -1332,14 +1379,15 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nor_4 : function is "NOR" ;
   attribute recursive_synthesis of nor_4 : function is true ;
-  attribute pin_bit_information of nor_4 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nor_4 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   -- Vectored primitive <gate> 5 input functions
@@ -1372,15 +1420,16 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of and_5 : function is "AND" ;
   attribute recursive_synthesis of and_5 : function is true ;
-  attribute pin_bit_information of and_5 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of and_5 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function or_5
@@ -1410,15 +1459,16 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of or_5 : function is "OR" ;
   attribute recursive_synthesis of or_5 : function is true ;
-  attribute pin_bit_information of or_5 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of or_5 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nand_5
@@ -1448,15 +1498,16 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nand_5 : function is "NAND" ;
   attribute recursive_synthesis of nand_5 : function is true ;
-  attribute pin_bit_information of nand_5 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nand_5 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nor_5
@@ -1486,15 +1537,16 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nor_5 : function is "NOR" ;
   attribute recursive_synthesis of nor_5 : function is true ;
-  attribute pin_bit_information of nor_5 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nor_5 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   -- Vectored primitive <gate> 6 input functions
@@ -1528,16 +1580,17 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of and_6 : function is "AND" ;
   attribute recursive_synthesis of and_6 : function is true ;
-  attribute pin_bit_information of and_6 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of and_6 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function or_6
@@ -1569,16 +1622,17 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of or_6 : function is "OR" ;
   attribute recursive_synthesis of or_6 : function is true ;
-  attribute pin_bit_information of or_6 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of or_6 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nand_6
@@ -1610,16 +1664,17 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nand_6 : function is "NAND" ;
   attribute recursive_synthesis of nand_6 : function is true ;
-  attribute pin_bit_information of nand_6 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nand_6 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nor_6
@@ -1651,16 +1706,17 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nor_6 : function is "NOR" ;
   attribute recursive_synthesis of nor_6 : function is true ;
-  attribute pin_bit_information of nor_6 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nor_6 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   -- Vectored primitive <gate> 7 input functions
@@ -1697,17 +1753,18 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of and_7 : function is "AND" ;
   attribute recursive_synthesis of and_7 : function is true ;
-  attribute pin_bit_information of and_7 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of and_7 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function or_7
@@ -1741,17 +1798,18 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of or_7 : function is "OR" ;
   attribute recursive_synthesis of or_7 : function is true ;
-  attribute pin_bit_information of or_7 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of or_7 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nand_7
@@ -1785,17 +1843,18 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nand_7 : function is "NAND" ;
   attribute recursive_synthesis of nand_7 : function is true ;
-  attribute pin_bit_information of nand_7 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nand_7 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nor_7
@@ -1829,17 +1888,18 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nor_7 : function is "NOR" ;
   attribute recursive_synthesis of nor_7 : function is true ;
-  attribute pin_bit_information of nor_7 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nor_7 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   -- Vectored primitive <gate> 8 input functions
@@ -1878,18 +1938,19 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of and_8 : function is "AND" ;
   attribute recursive_synthesis of and_8 : function is true ;
-  attribute pin_bit_information of and_8 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of and_8 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function or_8
@@ -1925,18 +1986,19 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of or_8 : function is "OR" ;
   attribute recursive_synthesis of or_8 : function is true ;
-  attribute pin_bit_information of or_8 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of or_8 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nand_8
@@ -1972,18 +2034,19 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nand_8 : function is "NAND" ;
   attribute recursive_synthesis of nand_8 : function is true ;
-  attribute pin_bit_information of nand_8 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nand_8 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function nor_8
@@ -2019,18 +2082,19 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of nor_8 : function is "NOR" ;
   attribute recursive_synthesis of nor_8 : function is true ;
-  attribute pin_bit_information of nor_8 : function is
-    (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of nor_8 : function is
+  --  (1 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   2 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","IN      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
 
   function decode( code  : std_ulogic_vector ) return  std_ulogic_vector;
@@ -2049,11 +2113,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of decode_2to4 : function is "VHDL-DECODE";
   attribute recursive_synthesis of decode_2to4 : function is true ;
-  attribute pin_bit_information of decode_2to4 : function is
-    (1 => ("   ","D1      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of decode_2to4 : function is
+  --  (1 => ("   ","D1      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function decode_3to8
@@ -2067,11 +2132,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of decode_3to8 : function is "VHDL-DECODE";
   attribute recursive_synthesis of decode_3to8 : function is true ;
-  attribute pin_bit_information of decode_3to8 : function is
-    (1 => ("   ","D2      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of decode_3to8 : function is
+  --  (1 => ("   ","D2      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function decode_4to16
@@ -2085,11 +2151,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of decode_4to16 : function is "VHDL-DECODE";
   attribute recursive_synthesis of decode_4to16 : function is true ;
-  attribute pin_bit_information of decode_4to16 : function is
-    (1 => ("   ","D3      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of decode_4to16 : function is
+  --  (1 => ("   ","D3      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function decode_5to32
@@ -2103,11 +2170,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of decode_5to32 : function is "VHDL-DECODE";
   attribute recursive_synthesis of decode_5to32 : function is true ;
-  attribute pin_bit_information of decode_5to32 : function is
-    (1 => ("   ","D4      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of decode_5to32 : function is
+  --  (1 => ("   ","D4      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
   function decode_6to64
@@ -2121,11 +2189,12 @@ package std_ulogic_function_support is
   -- synopsys translate_off
   attribute btr_name            of decode_6to64 : function is "VHDL-DECODE";
   attribute recursive_synthesis of decode_6to64 : function is true ;
-  attribute pin_bit_information of decode_6to64 : function is
-    (1 => ("   ","D5      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","PASS    ","    ","              "),
-     3 => ("   ","PASS    ","    ","              "),
-     4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of decode_6to64 : function is
+  --  (1 => ("   ","D5      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","PASS    ","    ","              "),
+  --   3 => ("   ","PASS    ","    ","              "),
+  --   4 => ("   ","F0      ","INCR","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
 
 end std_ulogic_function_support;

--- a/rel/src/vhdl/ibm/std_ulogic_function_support.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_function_support.vhdl
@@ -124,7 +124,7 @@ package std_ulogic_function_support is
 
   --  Generic Terminator
   procedure terminator
-    (in0   : in std_ulogic              
+    (in0   : in std_ulogic
      -- synopsys translate_off
       ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -132,7 +132,7 @@ package std_ulogic_function_support is
      );
 
   procedure terminator
-    (in0   : in std_ulogic_vector       
+    (in0   : in std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -149,7 +149,7 @@ package std_ulogic_function_support is
 
   --  Generic Delay
   function delay
-    (in0   : std_ulogic              
+    (in0   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -158,7 +158,7 @@ package std_ulogic_function_support is
     return std_ulogic               ;
 
   function delay
-    (in0   : std_ulogic_vector       
+    (in0   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -179,7 +179,7 @@ package std_ulogic_function_support is
 
   --  Generic Buffer
   function buff
-    (in0   : std_ulogic              
+    (in0   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -188,7 +188,7 @@ package std_ulogic_function_support is
     return std_ulogic               ;
 
   function buff
-    (in0   : std_ulogic_vector       
+    (in0   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -209,7 +209,7 @@ package std_ulogic_function_support is
 
   -- Invert single bit
   function invert
-    (in0   : std_ulogic 
+    (in0   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -238,7 +238,7 @@ package std_ulogic_function_support is
   -- Compare single bit
   function compare
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -269,7 +269,7 @@ package std_ulogic_function_support is
   --  Parity Functions
   --  General XOR_Tree Building Parity Function
   function parity
-    (in0   : std_ulogic_vector           
+    (in0   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -286,7 +286,7 @@ package std_ulogic_function_support is
      4 => ("   ","OUT     ","SAME","PIN_BIT_SCALAR"));
   -- Synopsys translate_on
   function parity_map
-    (in0   : std_ulogic_vector       
+    (in0   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -386,7 +386,7 @@ package std_ulogic_function_support is
      add_2 : in  std_ulogic     ;
      cryin : in  std_ulogic     ;
      signal sum   : out std_ulogic     ;
-     signal carry : out std_ulogic     
+     signal carry : out std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -397,7 +397,7 @@ package std_ulogic_function_support is
      add_2 : in  std_ulogic_vector ;
      cryin : in  std_ulogic_vector ;
      signal sum   : out std_ulogic_vector ;
-     signal carry : out std_ulogic_vector 
+     signal carry : out std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -486,7 +486,7 @@ package std_ulogic_function_support is
   -- Synopsys translate_on
 
   function vector_tie_1
-    (width : integer        := 1 
+    (width : integer        := 1
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -629,7 +629,7 @@ package std_ulogic_function_support is
     return std_ulogic_vector ;
   function gate_and
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -667,7 +667,7 @@ package std_ulogic_function_support is
     return std_ulogic_vector ;
   function gate_or
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -705,7 +705,7 @@ package std_ulogic_function_support is
     return std_ulogic_vector ;
   function gate_nand
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -743,7 +743,7 @@ package std_ulogic_function_support is
     return std_ulogic_vector ;
   function gate_nor
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -772,7 +772,7 @@ package std_ulogic_function_support is
 
   function gate_xor
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -801,7 +801,7 @@ package std_ulogic_function_support is
 
   function gate_xnor
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
      -- synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -827,13 +827,13 @@ package std_ulogic_function_support is
      4 => ("   ","PASS    ","    ","              "),
      5 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
-  
+
   -- Vectored primitive <gate> 2 input functions
   -- Single bit case
   -- Multiple vectors logically <gate>ed bitwise
   function and_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -842,7 +842,7 @@ package std_ulogic_function_support is
     return std_ulogic ;
   function and_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -862,7 +862,7 @@ package std_ulogic_function_support is
 
   function or_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -871,7 +871,7 @@ package std_ulogic_function_support is
     return std_ulogic ;
   function or_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -891,7 +891,7 @@ package std_ulogic_function_support is
 
   function nand_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -900,7 +900,7 @@ package std_ulogic_function_support is
     return std_ulogic ;
   function nand_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -920,7 +920,7 @@ package std_ulogic_function_support is
 
   function nor_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -929,7 +929,7 @@ package std_ulogic_function_support is
     return std_ulogic ;
   function nor_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -949,7 +949,7 @@ package std_ulogic_function_support is
 
   function xor_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -958,7 +958,7 @@ package std_ulogic_function_support is
     return std_ulogic ;
   function xor_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -978,7 +978,7 @@ package std_ulogic_function_support is
 
   function xnor_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -987,7 +987,7 @@ package std_ulogic_function_support is
     return std_ulogic ;
   function xnor_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1010,7 +1010,7 @@ package std_ulogic_function_support is
   function and_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1021,7 +1021,7 @@ package std_ulogic_function_support is
   function and_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1043,7 +1043,7 @@ package std_ulogic_function_support is
   function or_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1053,7 +1053,7 @@ package std_ulogic_function_support is
   function or_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1075,7 +1075,7 @@ package std_ulogic_function_support is
   function nand_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1085,7 +1085,7 @@ package std_ulogic_function_support is
   function nand_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1107,7 +1107,7 @@ package std_ulogic_function_support is
   function nor_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1117,7 +1117,7 @@ package std_ulogic_function_support is
   function nor_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1139,7 +1139,7 @@ package std_ulogic_function_support is
   function xor_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1149,7 +1149,7 @@ package std_ulogic_function_support is
   function xor_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1171,7 +1171,7 @@ package std_ulogic_function_support is
   function xnor_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1181,7 +1181,7 @@ package std_ulogic_function_support is
   function xnor_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1206,7 +1206,7 @@ package std_ulogic_function_support is
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
      in2   : std_ulogic ;
-     in3   : std_ulogic 
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1217,7 +1217,7 @@ package std_ulogic_function_support is
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
-     in3   : std_ulogic_vector 
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1241,7 +1241,7 @@ package std_ulogic_function_support is
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
      in2   : std_ulogic ;
-     in3   : std_ulogic 
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1252,7 +1252,7 @@ package std_ulogic_function_support is
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
-     in3   : std_ulogic_vector 
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1276,7 +1276,7 @@ package std_ulogic_function_support is
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
      in2   : std_ulogic ;
-     in3   : std_ulogic 
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1287,7 +1287,7 @@ package std_ulogic_function_support is
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
-     in3   : std_ulogic_vector 
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1311,7 +1311,7 @@ package std_ulogic_function_support is
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
      in2   : std_ulogic ;
-     in3   : std_ulogic 
+     in3   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1322,7 +1322,7 @@ package std_ulogic_function_support is
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
-     in3   : std_ulogic_vector 
+     in3   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1350,7 +1350,7 @@ package std_ulogic_function_support is
      in1   : std_ulogic ;
      in2   : std_ulogic ;
      in3   : std_ulogic ;
-     in4   : std_ulogic 
+     in4   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1362,7 +1362,7 @@ package std_ulogic_function_support is
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
-     in4   : std_ulogic_vector 
+     in4   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1388,7 +1388,7 @@ package std_ulogic_function_support is
      in1   : std_ulogic ;
      in2   : std_ulogic ;
      in3   : std_ulogic ;
-     in4   : std_ulogic 
+     in4   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1400,7 +1400,7 @@ package std_ulogic_function_support is
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
-     in4   : std_ulogic_vector 
+     in4   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1426,7 +1426,7 @@ package std_ulogic_function_support is
      in1   : std_ulogic ;
      in2   : std_ulogic ;
      in3   : std_ulogic ;
-     in4   : std_ulogic 
+     in4   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1438,7 +1438,7 @@ package std_ulogic_function_support is
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
-     in4   : std_ulogic_vector 
+     in4   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1464,7 +1464,7 @@ package std_ulogic_function_support is
      in1   : std_ulogic ;
      in2   : std_ulogic ;
      in3   : std_ulogic ;
-     in4   : std_ulogic 
+     in4   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1476,7 +1476,7 @@ package std_ulogic_function_support is
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
-     in4   : std_ulogic_vector 
+     in4   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1505,7 +1505,7 @@ package std_ulogic_function_support is
      in2   : std_ulogic ;
      in3   : std_ulogic ;
      in4   : std_ulogic ;
-     in5   : std_ulogic 
+     in5   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1518,7 +1518,7 @@ package std_ulogic_function_support is
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
-     in5   : std_ulogic_vector 
+     in5   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1546,7 +1546,7 @@ package std_ulogic_function_support is
      in2   : std_ulogic ;
      in3   : std_ulogic ;
      in4   : std_ulogic ;
-     in5   : std_ulogic 
+     in5   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1559,7 +1559,7 @@ package std_ulogic_function_support is
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
-     in5   : std_ulogic_vector 
+     in5   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1587,7 +1587,7 @@ package std_ulogic_function_support is
      in2   : std_ulogic ;
      in3   : std_ulogic ;
      in4   : std_ulogic ;
-     in5   : std_ulogic 
+     in5   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1600,7 +1600,7 @@ package std_ulogic_function_support is
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
-     in5   : std_ulogic_vector 
+     in5   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1628,7 +1628,7 @@ package std_ulogic_function_support is
      in2   : std_ulogic ;
      in3   : std_ulogic ;
      in4   : std_ulogic ;
-     in5   : std_ulogic 
+     in5   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1641,7 +1641,7 @@ package std_ulogic_function_support is
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
-     in5   : std_ulogic_vector 
+     in5   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1673,7 +1673,7 @@ package std_ulogic_function_support is
      in3   : std_ulogic ;
      in4   : std_ulogic ;
      in5   : std_ulogic ;
-     in6   : std_ulogic 
+     in6   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1687,7 +1687,7 @@ package std_ulogic_function_support is
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
-     in6   : std_ulogic_vector 
+     in6   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1717,7 +1717,7 @@ package std_ulogic_function_support is
      in3   : std_ulogic ;
      in4   : std_ulogic ;
      in5   : std_ulogic ;
-     in6   : std_ulogic 
+     in6   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1731,7 +1731,7 @@ package std_ulogic_function_support is
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
-     in6   : std_ulogic_vector 
+     in6   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1761,7 +1761,7 @@ package std_ulogic_function_support is
      in3   : std_ulogic ;
      in4   : std_ulogic ;
      in5   : std_ulogic ;
-     in6   : std_ulogic 
+     in6   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1775,7 +1775,7 @@ package std_ulogic_function_support is
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
-     in6   : std_ulogic_vector 
+     in6   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1805,7 +1805,7 @@ package std_ulogic_function_support is
      in3   : std_ulogic ;
      in4   : std_ulogic ;
      in5   : std_ulogic ;
-     in6   : std_ulogic 
+     in6   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1819,7 +1819,7 @@ package std_ulogic_function_support is
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
-     in6   : std_ulogic_vector 
+     in6   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1853,7 +1853,7 @@ package std_ulogic_function_support is
      in4   : std_ulogic ;
      in5   : std_ulogic ;
      in6   : std_ulogic ;
-     in7   : std_ulogic 
+     in7   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1868,7 +1868,7 @@ package std_ulogic_function_support is
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
      in6   : std_ulogic_vector ;
-     in7   : std_ulogic_vector 
+     in7   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1900,7 +1900,7 @@ package std_ulogic_function_support is
      in4   : std_ulogic ;
      in5   : std_ulogic ;
      in6   : std_ulogic ;
-     in7   : std_ulogic 
+     in7   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1915,7 +1915,7 @@ package std_ulogic_function_support is
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
      in6   : std_ulogic_vector ;
-     in7   : std_ulogic_vector 
+     in7   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1947,7 +1947,7 @@ package std_ulogic_function_support is
      in4   : std_ulogic ;
      in5   : std_ulogic ;
      in6   : std_ulogic ;
-     in7   : std_ulogic 
+     in7   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1962,7 +1962,7 @@ package std_ulogic_function_support is
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
      in6   : std_ulogic_vector ;
-     in7   : std_ulogic_vector 
+     in7   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -1994,7 +1994,7 @@ package std_ulogic_function_support is
      in4   : std_ulogic ;
      in5   : std_ulogic ;
      in6   : std_ulogic ;
-     in7   : std_ulogic 
+     in7   : std_ulogic
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2009,7 +2009,7 @@ package std_ulogic_function_support is
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
      in6   : std_ulogic_vector ;
-     in7   : std_ulogic_vector 
+     in7   : std_ulogic_vector
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2032,7 +2032,7 @@ package std_ulogic_function_support is
      10 => ("   ","PASS    ","    ","              "),
      11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- Synopsys translate_on
-  
+
   function decode( code  : std_ulogic_vector ) return  std_ulogic_vector;
   -- Synopsys translate_off
   attribute functionality of decode: function is "DECODER";
@@ -2057,7 +2057,7 @@ package std_ulogic_function_support is
   -- Synopsys translate_on
 
   function decode_3to8
-    (code  : std_ulogic_vector(0 to 2) 
+    (code  : std_ulogic_vector(0 to 2)
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2075,7 +2075,7 @@ package std_ulogic_function_support is
   -- Synopsys translate_on
 
   function decode_4to16
-    (code  : std_ulogic_vector(0 to 3) 
+    (code  : std_ulogic_vector(0 to 3)
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2093,7 +2093,7 @@ package std_ulogic_function_support is
   -- Synopsys translate_on
 
   function decode_5to32
-    (code  : std_ulogic_vector(0 to 4) 
+    (code  : std_ulogic_vector(0 to 4)
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2111,7 +2111,7 @@ package std_ulogic_function_support is
   -- Synopsys translate_on
 
   function decode_6to64
-    (code  : std_ulogic_vector(0 to 5) 
+    (code  : std_ulogic_vector(0 to 5)
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2160,7 +2160,7 @@ package body std_ulogic_function_support is
 
   --  Generic Terminator
   procedure terminator
-    (in0     : in std_ulogic         
+    (in0     : in std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2168,18 +2168,18 @@ package body std_ulogic_function_support is
      )
   is
     variable result     : std_ulogic ;
-  -- synopsys translate_off 
+  -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-  -- Synopsys translate_on 
+  -- Synopsys translate_on
   begin
     result := in0 ;
   end terminator ;
 
   procedure terminator
-    (in0     : in std_ulogic_vector    
+    (in0     : in std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2187,19 +2187,19 @@ package body std_ulogic_function_support is
      )
   is
     variable result     : std_ulogic_vector (0 to in0'length-1);
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1);
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := in0 ;
   end terminator ;
 
   --  Generic Delay
   function delay
-    (in0   : std_ulogic             
+    (in0   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2208,12 +2208,12 @@ package body std_ulogic_function_support is
     return std_ulogic
   is
     variable result     : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     -- initialize variable attribute values
     result  := in0;
@@ -2221,7 +2221,7 @@ package body std_ulogic_function_support is
   end delay ;
 
   function delay
-    (in0   : std_ulogic_vector      
+    (in0   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2230,19 +2230,19 @@ package body std_ulogic_function_support is
     return std_ulogic_vector
   is
     variable result     : std_ulogic_vector (0 to in0'length-1);
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result  := in0;
     return result;
   end delay ;
 
   function buff
-    (in0   : std_ulogic             
+    (in0   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2251,19 +2251,19 @@ package body std_ulogic_function_support is
     return std_ulogic
   is
     variable result     : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result  := in0;
     return result;
   end buff  ;
 
   function buff
-    (in0   : std_ulogic_vector      
+    (in0   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2272,12 +2272,12 @@ package body std_ulogic_function_support is
     return std_ulogic_vector
   is
     variable result     : std_ulogic_vector (0 to in0'length-1);
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result  := in0;
     return result;
@@ -2285,7 +2285,7 @@ package body std_ulogic_function_support is
 
 -- inverter single bit
   function invert
-    (in0   : std_ulogic 
+    (in0   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2294,12 +2294,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result     : std_ulogic;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result  := not in0;
     return result;
@@ -2316,12 +2316,12 @@ package body std_ulogic_function_support is
      return std_ulogic_vector
   is
     variable result     : std_ulogic_vector (0 to in0'length-1);
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result  := not in0;
     return result;
@@ -2330,7 +2330,7 @@ package body std_ulogic_function_support is
   -- Comparator
   function compare
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2339,12 +2339,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result     : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result  := in0 = in1 ;
     return result;
@@ -2362,12 +2362,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result     : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result  := in0 = in1 ;
     return result;
@@ -2375,7 +2375,7 @@ package body std_ulogic_function_support is
 
   --  General XOR_Tree Building Parity Function
   function parity
-    (In0   : std_ulogic_vector           
+    (In0   : std_ulogic_vector
   -- Synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -2383,12 +2383,12 @@ package body std_ulogic_function_support is
      )
     return Std_uLogic
   is
-    -- Synopsys translate_off 
+    -- Synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- Synopsys translate_on 
+    -- Synopsys translate_on
     variable result : std_ulogic;
   begin
     result := in0(in0'low);
@@ -2400,7 +2400,7 @@ package body std_ulogic_function_support is
 
   --  Specific Size Parity Block Map Function
   function parity_map
-    (In0   : std_ulogic_vector      
+    (In0   : std_ulogic_vector
      -- Synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -2423,9 +2423,9 @@ package body std_ulogic_function_support is
     return result;
   end parity_map ;
 
--- Parity gneration/checking functions  
+-- Parity gneration/checking functions
   function parity_gen_odd
-    (in0   : std_ulogic_vector      
+    (in0   : std_ulogic_vector
   -- Synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -2433,12 +2433,12 @@ package body std_ulogic_function_support is
      )
     return std_ulogic
   is
-    -- Synopsys translate_off 
+    -- Synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- Synopsys translate_on 
+    -- Synopsys translate_on
     variable result : std_ulogic;
   begin
     result := in0(in0'low);
@@ -2449,7 +2449,7 @@ package body std_ulogic_function_support is
   end parity_gen_odd ;
 
   function parity_gen_even
-    (in0   : std_ulogic_vector      
+    (in0   : std_ulogic_vector
   -- Synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -2457,12 +2457,12 @@ package body std_ulogic_function_support is
      )
     return std_ulogic
   is
-    -- Synopsys translate_off 
+    -- Synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- Synopsys translate_on 
+    -- Synopsys translate_on
     variable result : std_ulogic;
   begin
     result := in0(in0'low);
@@ -2473,7 +2473,7 @@ package body std_ulogic_function_support is
   end parity_gen_even ;
 
   function is_parity_odd
-    (in0   : std_ulogic_vector      
+    (in0   : std_ulogic_vector
   -- Synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -2481,12 +2481,12 @@ package body std_ulogic_function_support is
      )
     return std_ulogic
   is
-    -- Synopsys translate_off 
+    -- Synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- Synopsys translate_on 
+    -- Synopsys translate_on
     variable result : std_ulogic;
   begin
     result := in0(in0'low);
@@ -2497,7 +2497,7 @@ package body std_ulogic_function_support is
   end is_parity_odd ;
 
   function is_parity_even
-    (in0   : std_ulogic_vector      
+    (in0   : std_ulogic_vector
      -- Synopsys translate_off
      ;btr   : in String                 :=""
      ;blkdata  : in String              :=""
@@ -2505,12 +2505,12 @@ package body std_ulogic_function_support is
      )
     return std_ulogic
   is
-    -- Synopsys translate_off 
+    -- Synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- Synopsys translate_on 
+    -- Synopsys translate_on
     variable result : std_ulogic;
   begin
     result := in0(in0'low);
@@ -2522,7 +2522,7 @@ package body std_ulogic_function_support is
 
   function and_reduce
     (in0   : std_ulogic_vector
-  -- synopsys translate_off 
+  -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
   -- synopsys translate_on
@@ -2530,12 +2530,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result     : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := in0(in0'left) ;
     for i in in0'range loop
@@ -2556,11 +2556,11 @@ package body std_ulogic_function_support is
   is
     variable result     : std_ulogic ;
     variable block_data : string(1 to 1) ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := in0(in0'left) ;
     for i in in0'range loop
@@ -2580,12 +2580,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result     : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := in0(in0'left) ;
     for i in in0'range loop
@@ -2605,12 +2605,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result     : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := in0(in0'left) ;
     for i in in0'range loop
@@ -2630,12 +2630,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result     : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := '0' ;
     for i in in0'range loop
@@ -2655,12 +2655,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result     : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := '0' ;
     for i in in0'range loop
@@ -2672,7 +2672,7 @@ package body std_ulogic_function_support is
 
   function  gate_and
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2681,12 +2681,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := gate and   in0 ;
     return result;
@@ -2717,7 +2717,7 @@ package body std_ulogic_function_support is
 
   function  gate_or
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2726,12 +2726,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := gate or    in0 ;
     return result;
@@ -2762,7 +2762,7 @@ package body std_ulogic_function_support is
 
   function  gate_nand
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2771,12 +2771,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := gate nand  in0 ;
     return result;
@@ -2792,12 +2792,12 @@ package body std_ulogic_function_support is
      )
      return std_ulogic_vector
   is
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
     variable result     : std_ulogic_vector(0 to in0'length-1);
     subtype vec_length is std_ulogic_vector(0 to in0'length-1);
   begin
@@ -2807,7 +2807,7 @@ package body std_ulogic_function_support is
 
   function  gate_nor
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2816,12 +2816,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result : std_ulogic;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := gate nor   in0 ;
     return result;
@@ -2837,13 +2837,13 @@ package body std_ulogic_function_support is
      )
      return std_ulogic_vector
   is
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
-    variable result     : std_ulogic_vector(0 to in0'length-1); 
+    -- synopsys translate_on
+    variable result     : std_ulogic_vector(0 to in0'length-1);
     subtype vec_length is std_ulogic_vector(0 to in0'length-1);
   begin
     result := in0 nor vec_length'(0 to in0'length-1 => gate) ;
@@ -2852,7 +2852,7 @@ package body std_ulogic_function_support is
 
   function  gate_xor
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -2861,12 +2861,12 @@ package body std_ulogic_function_support is
      return std_ulogic
   is
     variable result : std_ulogic ;
-    -- synopsys translate_off 
+    -- synopsys translate_off
     variable block_data : string(1 to 1) ;
     attribute dynamic_block_data of block_data : variable is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
-    -- synopsys translate_on 
+    -- synopsys translate_on
   begin
     result := gate xor   in0 ;
     return result;
@@ -2897,7 +2897,7 @@ package body std_ulogic_function_support is
 
   function  gate_xnor
     (gate  : std_ulogic ;
-     in0   : std_ulogic 
+     in0   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3022,7 +3022,7 @@ package body std_ulogic_function_support is
     end loop;
     result := in0 and vec_length'(0 to in0'length-1 => gate_int) ;
     result := not result ;
-    return result; 
+    return result;
   end gate_nand;
 
   function gate_nor
@@ -3056,7 +3056,7 @@ package body std_ulogic_function_support is
 
   function xor_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3078,7 +3078,7 @@ package body std_ulogic_function_support is
 
   function xor_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3101,7 +3101,7 @@ package body std_ulogic_function_support is
   function xor_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3124,7 +3124,7 @@ package body std_ulogic_function_support is
   function xor_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3146,7 +3146,7 @@ package body std_ulogic_function_support is
 
   function xnor_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3168,7 +3168,7 @@ package body std_ulogic_function_support is
 
   function xnor_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3191,7 +3191,7 @@ package body std_ulogic_function_support is
   function xnor_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3214,7 +3214,7 @@ package body std_ulogic_function_support is
   function xnor_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3236,7 +3236,7 @@ package body std_ulogic_function_support is
 
   function and_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3258,7 +3258,7 @@ package body std_ulogic_function_support is
 
   function and_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3281,7 +3281,7 @@ package body std_ulogic_function_support is
   function and_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3304,7 +3304,7 @@ package body std_ulogic_function_support is
   function and_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3328,7 +3328,7 @@ package body std_ulogic_function_support is
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
      in2   : std_ulogic ;
-     in3   : std_ulogic 
+     in3   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3352,7 +3352,7 @@ package body std_ulogic_function_support is
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
-     in3   : std_ulogic_vector 
+     in3   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3377,7 +3377,7 @@ package body std_ulogic_function_support is
      in1   : std_ulogic ;
      in2   : std_ulogic ;
      in3   : std_ulogic ;
-     in4   : std_ulogic 
+     in4   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3402,7 +3402,7 @@ package body std_ulogic_function_support is
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
-     in4   : std_ulogic_vector 
+     in4   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3428,7 +3428,7 @@ package body std_ulogic_function_support is
      in2   : std_ulogic ;
      in3   : std_ulogic ;
      in4   : std_ulogic ;
-     in5   : std_ulogic 
+     in5   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3454,7 +3454,7 @@ package body std_ulogic_function_support is
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
-     in5   : std_ulogic_vector 
+     in5   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3481,7 +3481,7 @@ package body std_ulogic_function_support is
      in3   : std_ulogic ;
      in4   : std_ulogic ;
      in5   : std_ulogic ;
-     in6   : std_ulogic 
+     in6   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3508,7 +3508,7 @@ package body std_ulogic_function_support is
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
-     in6   : std_ulogic_vector 
+     in6   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3536,7 +3536,7 @@ package body std_ulogic_function_support is
      in4   : std_ulogic ;
      in5   : std_ulogic ;
      in6   : std_ulogic ;
-     in7   : std_ulogic 
+     in7   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3564,7 +3564,7 @@ package body std_ulogic_function_support is
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
      in6   : std_ulogic_vector ;
-     in7   : std_ulogic_vector 
+     in7   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3586,7 +3586,7 @@ package body std_ulogic_function_support is
 
   function or_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3608,7 +3608,7 @@ package body std_ulogic_function_support is
 
   function or_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3631,7 +3631,7 @@ package body std_ulogic_function_support is
   function or_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3654,7 +3654,7 @@ package body std_ulogic_function_support is
   function or_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3678,7 +3678,7 @@ package body std_ulogic_function_support is
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
      in2   : std_ulogic ;
-     in3   : std_ulogic 
+     in3   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3702,7 +3702,7 @@ package body std_ulogic_function_support is
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
-     in3   : std_ulogic_vector 
+     in3   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3727,7 +3727,7 @@ package body std_ulogic_function_support is
      in1   : std_ulogic ;
      in2   : std_ulogic ;
      in3   : std_ulogic ;
-     in4   : std_ulogic 
+     in4   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3752,7 +3752,7 @@ package body std_ulogic_function_support is
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
-     in4   : std_ulogic_vector 
+     in4   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3778,7 +3778,7 @@ package body std_ulogic_function_support is
      in2   : std_ulogic ;
      in3   : std_ulogic ;
      in4   : std_ulogic ;
-     in5   : std_ulogic 
+     in5   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3804,7 +3804,7 @@ package body std_ulogic_function_support is
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
-     in5   : std_ulogic_vector 
+     in5   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3831,7 +3831,7 @@ package body std_ulogic_function_support is
      in3   : std_ulogic ;
      in4   : std_ulogic ;
      in5   : std_ulogic ;
-     in6   : std_ulogic 
+     in6   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3858,7 +3858,7 @@ package body std_ulogic_function_support is
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
-     in6   : std_ulogic_vector 
+     in6   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3886,7 +3886,7 @@ package body std_ulogic_function_support is
      in4   : std_ulogic ;
      in5   : std_ulogic ;
      in6   : std_ulogic ;
-     in7   : std_ulogic 
+     in7   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3914,7 +3914,7 @@ package body std_ulogic_function_support is
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
      in6   : std_ulogic_vector ;
-     in7   : std_ulogic_vector 
+     in7   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3936,7 +3936,7 @@ package body std_ulogic_function_support is
 
   function nand_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3958,7 +3958,7 @@ package body std_ulogic_function_support is
 
   function nand_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -3981,7 +3981,7 @@ package body std_ulogic_function_support is
   function nand_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4004,7 +4004,7 @@ package body std_ulogic_function_support is
   function nand_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4028,7 +4028,7 @@ package body std_ulogic_function_support is
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
      in2   : std_ulogic ;
-     in3   : std_ulogic 
+     in3   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4052,7 +4052,7 @@ package body std_ulogic_function_support is
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
-     in3   : std_ulogic_vector 
+     in3   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4077,7 +4077,7 @@ package body std_ulogic_function_support is
      in1   : std_ulogic ;
      in2   : std_ulogic ;
      in3   : std_ulogic ;
-     in4   : std_ulogic 
+     in4   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4102,7 +4102,7 @@ package body std_ulogic_function_support is
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
-     in4   : std_ulogic_vector 
+     in4   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4128,7 +4128,7 @@ package body std_ulogic_function_support is
      in2   : std_ulogic ;
      in3   : std_ulogic ;
      in4   : std_ulogic ;
-     in5   : std_ulogic 
+     in5   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4154,7 +4154,7 @@ package body std_ulogic_function_support is
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
-     in5   : std_ulogic_vector 
+     in5   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4181,7 +4181,7 @@ package body std_ulogic_function_support is
      in3   : std_ulogic ;
      in4   : std_ulogic ;
      in5   : std_ulogic ;
-     in6   : std_ulogic 
+     in6   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4208,7 +4208,7 @@ package body std_ulogic_function_support is
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
-     in6   : std_ulogic_vector 
+     in6   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4236,7 +4236,7 @@ package body std_ulogic_function_support is
      in4   : std_ulogic ;
      in5   : std_ulogic ;
      in6   : std_ulogic ;
-     in7   : std_ulogic 
+     in7   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4264,7 +4264,7 @@ package body std_ulogic_function_support is
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
      in6   : std_ulogic_vector ;
-     in7   : std_ulogic_vector 
+     in7   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4286,7 +4286,7 @@ package body std_ulogic_function_support is
 
   function nor_2
     (in0   : std_ulogic ;
-     in1   : std_ulogic 
+     in1   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4308,7 +4308,7 @@ package body std_ulogic_function_support is
 
   function nor_2
     (in0   : std_ulogic_vector ;
-     in1   : std_ulogic_vector 
+     in1   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4331,7 +4331,7 @@ package body std_ulogic_function_support is
   function nor_3
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
-     in2   : std_ulogic 
+     in2   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4354,7 +4354,7 @@ package body std_ulogic_function_support is
   function nor_3
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
-     in2   : std_ulogic_vector 
+     in2   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4378,7 +4378,7 @@ package body std_ulogic_function_support is
     (in0   : std_ulogic ;
      in1   : std_ulogic ;
      in2   : std_ulogic ;
-     in3   : std_ulogic 
+     in3   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4402,7 +4402,7 @@ package body std_ulogic_function_support is
     (in0   : std_ulogic_vector ;
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
-     in3   : std_ulogic_vector 
+     in3   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4427,7 +4427,7 @@ package body std_ulogic_function_support is
      in1   : std_ulogic ;
      in2   : std_ulogic ;
      in3   : std_ulogic ;
-     in4   : std_ulogic 
+     in4   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4452,7 +4452,7 @@ package body std_ulogic_function_support is
      in1   : std_ulogic_vector ;
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
-     in4   : std_ulogic_vector 
+     in4   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4478,7 +4478,7 @@ package body std_ulogic_function_support is
      in2   : std_ulogic ;
      in3   : std_ulogic ;
      in4   : std_ulogic ;
-     in5   : std_ulogic 
+     in5   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4504,7 +4504,7 @@ package body std_ulogic_function_support is
      in2   : std_ulogic_vector ;
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
-     in5   : std_ulogic_vector 
+     in5   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4531,7 +4531,7 @@ package body std_ulogic_function_support is
      in3   : std_ulogic ;
      in4   : std_ulogic ;
      in5   : std_ulogic ;
-     in6   : std_ulogic 
+     in6   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4558,7 +4558,7 @@ package body std_ulogic_function_support is
      in3   : std_ulogic_vector ;
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
-     in6   : std_ulogic_vector 
+     in6   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4586,7 +4586,7 @@ package body std_ulogic_function_support is
      in4   : std_ulogic ;
      in5   : std_ulogic ;
      in6   : std_ulogic ;
-     in7   : std_ulogic 
+     in7   : std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4614,7 +4614,7 @@ package body std_ulogic_function_support is
      in4   : std_ulogic_vector ;
      in5   : std_ulogic_vector ;
      in6   : std_ulogic_vector ;
-     in7   : std_ulogic_vector 
+     in7   : std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4655,7 +4655,7 @@ package body std_ulogic_function_support is
   end tie_0;
 
   function vector_tie_0
-    (width : integer        := 1 
+    (width : integer        := 1
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4698,7 +4698,7 @@ package body std_ulogic_function_support is
   end tie_1;
 
   function vector_tie_1
-    (width : integer        := 1 
+    (width : integer        := 1
      -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4739,7 +4739,7 @@ package body std_ulogic_function_support is
   end decode;
 
   function decode_2to4
-    (code  : std_ulogic_vector(0 to 1) 
+    (code  : std_ulogic_vector(0 to 1)
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4766,7 +4766,7 @@ package body std_ulogic_function_support is
   end decode_2to4;
 
   function decode_3to8
-    (code  : std_ulogic_vector(0 to 2) 
+    (code  : std_ulogic_vector(0 to 2)
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4797,7 +4797,7 @@ package body std_ulogic_function_support is
   end decode_3to8;
 
   function decode_4to16
-    (code  : std_ulogic_vector(0 to 3) 
+    (code  : std_ulogic_vector(0 to 3)
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4836,7 +4836,7 @@ package body std_ulogic_function_support is
   end decode_4to16;
 
   function decode_5to32
-    (code  : std_ulogic_vector(0 to 4) 
+    (code  : std_ulogic_vector(0 to 4)
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4850,7 +4850,7 @@ package body std_ulogic_function_support is
       "CUE_BTR=/" & btr & "/" &
       blkdata ;
     -- synopsys translate_on
-    variable result : std_ulogic_vector(0 to 31) ; 
+    variable result : std_ulogic_vector(0 to 31) ;
   begin
     case  code is
       when "00000"  => result := "10000000000000000000000000000000";
@@ -4891,7 +4891,7 @@ package body std_ulogic_function_support is
   end decode_5to32;
 
   function decode_6to64
-    (code  : std_ulogic_vector(0 to 5) 
+    (code  : std_ulogic_vector(0 to 5)
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -4983,7 +4983,7 @@ package body std_ulogic_function_support is
      add_2 : in  std_ulogic     ;
      cryin : in  std_ulogic     ;
      signal sum   : out std_ulogic     ;
-     signal carry : out std_ulogic     
+     signal carry : out std_ulogic
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -5008,7 +5008,7 @@ package body std_ulogic_function_support is
      add_2 : in  std_ulogic_vector ;
      cryin : in  std_ulogic_vector ;
      signal sum   : out std_ulogic_vector ;
-     signal carry : out std_ulogic_vector 
+     signal carry : out std_ulogic_vector
   -- synopsys translate_off
      ;btr   : in string                 :=""
      ;blkdata  : in string              :=""
@@ -5026,10 +5026,10 @@ package body std_ulogic_function_support is
   begin
     -- synopsys translate_off
     assert (add_1'length = add_2'length)
-      report "Addends of Full_Add are not the same length." 
+      report "Addends of Full_Add are not the same length."
       severity error;
     assert (add_1'length = cryin'length) and (add_2'length = cryin'length)
-      report "Addends of Full_Add are not the same length as the CryIn." 
+      report "Addends of Full_Add are not the same length as the CryIn."
       severity error;
     -- synopsys translate_on
     sum_result   :=  add_1 xor add_2 xor  cryin;

--- a/rel/src/vhdl/ibm/std_ulogic_mux_support.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_mux_support.vhdl
@@ -45,13 +45,14 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name            of mux_2to1 : function is "VHDL-MUX" ;
   attribute recursive_synthesis of mux_2to1 : function is true;
-  attribute pin_bit_information of mux_2to1 : function is
-    (1 => ("   ","S0      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of mux_2to1 : function is
+  --  (1 => ("   ","S0      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function mux_4to1
@@ -80,15 +81,16 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name            of mux_4to1 : function is "VHDL-MUX" ;
   attribute recursive_synthesis of mux_4to1 : function is true;
-  attribute pin_bit_information of mux_4to1 : function is
-    (1 => ("   ","S1      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of mux_4to1 : function is
+  --  (1 => ("   ","S1      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function mux_8to1
@@ -125,19 +127,20 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name            of mux_8to1 : function is "VHDL-MUX" ;
   attribute recursive_synthesis of mux_8to1 : function is true;
-  attribute pin_bit_information of mux_8to1 : function is
-    (1 => ("   ","S2      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","D4      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D5      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","D6      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","D7      ","SAME","PIN_BIT_VECTOR"),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","PASS    ","    ","              "),
-     12 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of mux_8to1 : function is
+  --  (1 => ("   ","S2      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","D4      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D5      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","D6      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","D7      ","SAME","PIN_BIT_VECTOR"),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","PASS    ","    ","              "),
+  --   12 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function not_mux_2to1
@@ -162,13 +165,14 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name            of not_mux_2to1 : function is "VHDL-MUX" ;
   attribute recursive_synthesis of not_mux_2to1 : function is true;
-  attribute pin_bit_information of not_mux_2to1 : function is
-    (1 => ("   ","S0      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","PASS    ","    ","              "),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of not_mux_2to1 : function is
+  --  (1 => ("   ","S0      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","PASS    ","    ","              "),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function not_mux_4to1
@@ -197,15 +201,16 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name            of not_mux_4to1 : function is "VHDL-MUX" ;
   attribute recursive_synthesis of not_mux_4to1 : function is true;
-  attribute pin_bit_information of not_mux_4to1 : function is
-    (1 => ("   ","S1      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of not_mux_4to1 : function is
+  --  (1 => ("   ","S1      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function not_mux_8to1
@@ -242,19 +247,20 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name            of not_mux_8to1 : function is "VHDL-MUX" ;
   attribute recursive_synthesis of not_mux_8to1 : function is true;
-  attribute pin_bit_information of not_mux_8to1 : function is
-    (1 => ("   ","S2      ","DECR","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     4 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
-     6 => ("   ","D4      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","D5      ","SAME","PIN_BIT_VECTOR"),
-     8 => ("   ","D6      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","D7      ","SAME","PIN_BIT_VECTOR"),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","PASS    ","    ","              "),
-     12 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of not_mux_8to1 : function is
+  --  (1 => ("   ","S2      ","DECR","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   4 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
+  --   6 => ("   ","D4      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","D5      ","SAME","PIN_BIT_VECTOR"),
+  --   8 => ("   ","D6      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","D7      ","SAME","PIN_BIT_VECTOR"),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","PASS    ","    ","              "),
+  --   12 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   -- Primitive selector input functions
@@ -282,14 +288,15 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name   of select_1of2 : function is "VHDL-SELECT" ;
   attribute recursive_synthesis of select_1of2 : function is true;
-  attribute pin_bit_information of select_1of2 : function is
-    (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of select_1of2 : function is
+  --  (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function select_1of3
@@ -320,16 +327,17 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name   of select_1of3 : function is "VHDL-SELECT" ;
   attribute recursive_synthesis of select_1of3 : function is true;
-  attribute pin_bit_information of select_1of3 : function is
-    (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of select_1of3 : function is
+  --  (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function select_1of4
@@ -364,18 +372,19 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name   of select_1of4 : function is "VHDL-SELECT" ;
   attribute recursive_synthesis of select_1of4 : function is true;
-  attribute pin_bit_information of select_1of4 : function is
-    (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","S3      ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of select_1of4 : function is
+  --  (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","S3      ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function select_1of8
@@ -426,26 +435,27 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name   of select_1of8 : function is "VHDL-SELECT" ;
   attribute recursive_synthesis of select_1of8 : function is true;
-  attribute pin_bit_information of select_1of8 : function is
-    (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","S3      ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","S4      ","SAME","PIN_BIT_SCALAR"),
-     10 => ("   ","D4      ","SAME","PIN_BIT_VECTOR"),
-     11 => ("   ","S5      ","SAME","PIN_BIT_SCALAR"),
-     12 => ("   ","D5      ","SAME","PIN_BIT_VECTOR"),
-     13 => ("   ","S6      ","SAME","PIN_BIT_SCALAR"),
-     14 => ("   ","D6      ","SAME","PIN_BIT_VECTOR"),
-     15 => ("   ","S7      ","SAME","PIN_BIT_SCALAR"),
-     16 => ("   ","D7      ","SAME","PIN_BIT_VECTOR"),
-     17 => ("   ","PASS    ","    ","              "),
-     18 => ("   ","PASS    ","    ","              "),
-     19 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of select_1of8 : function is
+  --  (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","S3      ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","S4      ","SAME","PIN_BIT_SCALAR"),
+  --   10 => ("   ","D4      ","SAME","PIN_BIT_VECTOR"),
+  --   11 => ("   ","S5      ","SAME","PIN_BIT_SCALAR"),
+  --   12 => ("   ","D5      ","SAME","PIN_BIT_VECTOR"),
+  --   13 => ("   ","S6      ","SAME","PIN_BIT_SCALAR"),
+  --   14 => ("   ","D6      ","SAME","PIN_BIT_VECTOR"),
+  --   15 => ("   ","S7      ","SAME","PIN_BIT_SCALAR"),
+  --   16 => ("   ","D7      ","SAME","PIN_BIT_VECTOR"),
+  --   17 => ("   ","PASS    ","    ","              "),
+  --   18 => ("   ","PASS    ","    ","              "),
+  --   19 => ("   ","OUT     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function not_select_1of2
@@ -472,14 +482,15 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name   of not_select_1of2 : function is "VHDL-SELECT" ;
   attribute recursive_synthesis of not_select_1of2 : function is true;
-  attribute pin_bit_information of not_select_1of2 : function is
-    (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","PASS    ","    ","              "),
-     6 => ("   ","PASS    ","    ","              "),
-     7 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of not_select_1of2 : function is
+  --  (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","PASS    ","    ","              "),
+  --   6 => ("   ","PASS    ","    ","              "),
+  --   7 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function not_select_1of3
@@ -510,16 +521,17 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name   of not_select_1of3 : function is "VHDL-SELECT" ;
   attribute recursive_synthesis of not_select_1of3 : function is true;
-  attribute PIN_BIT_INFORMATION of not_select_1of3 : function is
-    (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","PASS    ","    ","              "),
-     8 => ("   ","PASS    ","    ","              "),
-     9 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute PIN_BIT_INFORMATION of not_select_1of3 : function is
+  --  (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","PASS    ","    ","              "),
+  --   8 => ("   ","PASS    ","    ","              "),
+  --   9 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function not_select_1of4
@@ -554,18 +566,19 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name   of not_select_1of4 : function is "VHDL-SELECT" ;
   attribute recursive_synthesis of not_select_1of4 : function is true;
-  attribute pin_bit_information of not_select_1of4 : function is
-    (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","S3      ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","PASS    ","    ","              "),
-     10 => ("   ","PASS    ","    ","              "),
-     11 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of not_select_1of4 : function is
+  --  (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","S3      ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","PASS    ","    ","              "),
+  --   10 => ("   ","PASS    ","    ","              "),
+  --   11 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
   function not_select_1of8
@@ -616,26 +629,27 @@ package std_ulogic_mux_support is
   -- synopsys translate_off
   attribute btr_name   of not_select_1of8 : function is "VHDL-SELECT" ;
   attribute recursive_synthesis of not_select_1of8 : function is true;
-  attribute pin_bit_information of not_select_1of8 : function is
-    (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
-     2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
-     3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
-     4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
-     5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
-     6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
-     7 => ("   ","S3      ","SAME","PIN_BIT_SCALAR"),
-     8 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
-     9 => ("   ","S4      ","SAME","PIN_BIT_SCALAR"),
-     10 => ("   ","D4      ","SAME","PIN_BIT_VECTOR"),
-     11 => ("   ","S5      ","SAME","PIN_BIT_SCALAR"),
-     12 => ("   ","D5      ","SAME","PIN_BIT_VECTOR"),
-     13 => ("   ","S6      ","SAME","PIN_BIT_SCALAR"),
-     14 => ("   ","D6      ","SAME","PIN_BIT_VECTOR"),
-     15 => ("   ","S7      ","SAME","PIN_BIT_SCALAR"),
-     16 => ("   ","D7      ","SAME","PIN_BIT_VECTOR"),
-     17 => ("   ","PASS    ","    ","              "),
-     18 => ("   ","PASS    ","    ","              "),
-     19 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of not_select_1of8 : function is
+  --  (1 => ("   ","S0      ","SAME","PIN_BIT_SCALAR"),
+  --   2 => ("   ","D0      ","SAME","PIN_BIT_VECTOR"),
+  --   3 => ("   ","S1      ","SAME","PIN_BIT_SCALAR"),
+  --   4 => ("   ","D1      ","SAME","PIN_BIT_VECTOR"),
+  --   5 => ("   ","S2      ","SAME","PIN_BIT_SCALAR"),
+  --   6 => ("   ","D2      ","SAME","PIN_BIT_VECTOR"),
+  --   7 => ("   ","S3      ","SAME","PIN_BIT_SCALAR"),
+  --   8 => ("   ","D3      ","SAME","PIN_BIT_VECTOR"),
+  --   9 => ("   ","S4      ","SAME","PIN_BIT_SCALAR"),
+  --   10 => ("   ","D4      ","SAME","PIN_BIT_VECTOR"),
+  --   11 => ("   ","S5      ","SAME","PIN_BIT_SCALAR"),
+  --   12 => ("   ","D5      ","SAME","PIN_BIT_VECTOR"),
+  --   13 => ("   ","S6      ","SAME","PIN_BIT_SCALAR"),
+  --   14 => ("   ","D6      ","SAME","PIN_BIT_VECTOR"),
+  --   15 => ("   ","S7      ","SAME","PIN_BIT_SCALAR"),
+  --   16 => ("   ","D7      ","SAME","PIN_BIT_VECTOR"),
+  --   17 => ("   ","PASS    ","    ","              "),
+  --   18 => ("   ","PASS    ","    ","              "),
+  --   19 => ("   ","INV     ","SAME","PIN_BIT_VECTOR"));
   -- synopsys translate_on
 
 end std_ulogic_mux_support;

--- a/rel/src/vhdl/ibm/std_ulogic_support.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_support.vhdl
@@ -212,9 +212,10 @@ package std_ulogic_support is
   -------------------------------------------------------------------
 
   attribute btr_name         of tconv  : function is "PASS";
-  attribute pin_bit_information of tconv : function is
-           (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
-            2 => ("   ","10      ","INCR","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of tconv : function is
+  --         (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
+  --          2 => ("   ","10      ","INCR","PIN_BIT_SCALAR"));
 -- Synopsys translate_on
 
   --============================================================================

--- a/rel/src/vhdl/ibm/std_ulogic_support.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_support.vhdl
@@ -26,8 +26,8 @@ package std_ulogic_support is
   attribute dc_allow: boolean;
   attribute type_convert: boolean;
   attribute recursive_synthesis: boolean;
-  attribute functionality: string;  
-  attribute btr_name: string;  
+  attribute functionality: string;
+  attribute btr_name: string;
   attribute block_data: string;
   type pbi_el_t is array(0 to 3) of string;
   type pbi_t is array(integer range <>) of pbi_el_t;
@@ -231,7 +231,7 @@ package std_ulogic_support is
 --==============================================================
   -- Shift and Rotate Functions
 --==============================================================
- 
+
   -- Id: S.1
   function shift_left (arg: std_ulogic_vector; count: natural) return std_ulogic_vector;
   -- Result subtype: std_ulogic_vector(ARG'LENGTH-1 downto 0)
@@ -255,12 +255,12 @@ package std_ulogic_support is
   function rotate_right (arg: std_ulogic_vector; count: natural) return std_ulogic_vector;
   -- Result subtype: std_ulogic_vector(ARG'LENGTH-1 downto 0)
   -- Result: Performs a rotate-right of an std_ulogic_vector vector COUNT times.
-  
+
   -- Id: S.9
   function "sll" (arg: std_ulogic_vector; count: integer) return std_ulogic_vector;
   -- Result subtype: std_ulogic_vector(ARG'LENGTH-1 downto 0)
   -- Result: SHIFT_LEFT(ARG, COUNT)
- 
+
   -- Id: S.11
   function "srl" (arg: std_ulogic_vector; count: integer) return std_ulogic_vector;
   -- Result subtype: std_ulogic_vector(ARG'LENGTH-1 downto 0)
@@ -270,7 +270,7 @@ package std_ulogic_support is
   function "rol" (arg: std_ulogic_vector; count: integer) return std_ulogic_vector;
   -- Result subtype: std_ulogic_vector(ARG'LENGTH-1 downto 0)
   -- Result: ROTATE_LEFT(ARG, COUNT)
-  
+
   -- Id: S.15
   function "ror" (arg: std_ulogic_vector; count: integer) return std_ulogic_vector;
   -- Result subtype: std_ulogic_vector(ARG'LENGTH-1 downto 0)
@@ -632,7 +632,7 @@ package body std_ulogic_support is
   function eq( l,r : std_ulogic_vector)  return std_ulogic  is
       variable result        : std_ulogic ;
   begin
-    result := std_match( l, r ) ; 
+    result := std_match( l, r ) ;
     --result := (l ?= r);
     return result;
   end eq;
@@ -653,8 +653,8 @@ package body std_ulogic_support is
     result := unsigned(l) > unsigned(r);
     if (result = true ) then
        return '1' ;
-    else 
-       return '0'; 
+    else
+       return '0';
     end if ;
   end gt;
 
@@ -666,8 +666,8 @@ package body std_ulogic_support is
     result := unsigned(l) >= unsigned(r);
     if (result = true ) then
        return '1' ;
-    else 
-       return '0'; 
+    else
+       return '0';
     end if ;
   end ge;
 
@@ -679,8 +679,8 @@ package body std_ulogic_support is
     result := unsigned(l) < unsigned(r);
     if (result = true ) then
        return '1' ;
-    else 
-       return '0'; 
+    else
+       return '0';
     end if ;
   end lt;
 
@@ -692,8 +692,8 @@ package body std_ulogic_support is
     result := unsigned(l) <= unsigned(r);
     if (result = true ) then
        return '1' ;
-    else 
-       return '0'; 
+    else
+       return '0';
     end if ;
   end le;
 
@@ -789,9 +789,9 @@ package body std_ulogic_support is
   -- pragma built_in SYN_UNSIGNED_TO_INTEGER
   begin
   -- Synopsys translate_off
-     int_result := 0;  
-     int_exp    := 0;  
-     new_value  := b;  
+     int_result := 0;
+     int_exp    := 0;
+     new_value  := b;
      for i in new_value'length to 1 loop
         if b(i)='1' then
            int_result := int_result + (2**int_exp);
@@ -986,7 +986,7 @@ package body std_ulogic_support is
     variable result : bit_vector(w-1 downto 0) ;
     variable ib     : integer;
     variable test   : integer;
-    -- pragma built_in SYN_INTEGER_TO_UNSIGNED  
+    -- pragma built_in SYN_INTEGER_TO_UNSIGNED
   begin
     if n < 0 then
       result := (others => '0');
@@ -1136,7 +1136,7 @@ package body std_ulogic_support is
   -------------------------------------------------------------------
 -- Synopsys translate_off
   function TConv  ( s : string ) return integer is
-    variable result : integer ; 
+    variable result : integer ;
     alias si : string( s'length downto 1 ) is s;
     variable invalid : boolean ;
   begin
@@ -1547,7 +1547,7 @@ package body std_ulogic_support is
       end case;
   end;
 
--- Synopsys translate_off 
+-- Synopsys translate_off
   function tconv  ( s : std_ulogic ) return character is
   begin
      case s is
@@ -1562,9 +1562,9 @@ package body std_ulogic_support is
         when others => return('X');
      end case;
   end;
--- Synopsys translate_on 
+-- Synopsys translate_on
 
--- Synopsys translate_off 
+-- Synopsys translate_off
   function tconv  ( s : std_ulogic ) return string is
   begin
      case s is
@@ -1579,7 +1579,7 @@ package body std_ulogic_support is
         when others => return("X");
      end case;
   end;
--- Synopsys translate_on 
+-- Synopsys translate_on
 
   function tconv  ( s : std_ulogic ) return integer is
   -- pragma built_in SYN_UNSIGNED_TO_INTEGER
@@ -1666,7 +1666,7 @@ package body std_ulogic_support is
      int_exp    := 0;
      invalid    := false ;
      new_value  := s ;
-     for i in new_value'length downto 1 loop 
+     for i in new_value'length downto 1 loop
         case new_value(i) is
            when '1' => int_result := int_result + (2**int_exp);
            when '0' => null;
@@ -2271,7 +2271,7 @@ package body std_ulogic_support is
   -- Id: M.1a
   function std_match (l, r: std_ulogic) return std_ulogic is
   begin
-    if (l ?= r) then    
+    if (l ?= r) then
        return '1' ;
     else
        return '0' ;
@@ -2282,9 +2282,9 @@ package body std_ulogic_support is
   function std_match (l, r: std_ulogic_vector) return std_ulogic is
     variable result : boolean ;
   begin
-    if (l ?= r) then    
+    if (l ?= r) then
        return '1' ;
-    else 
+    else
        return '0' ;
     end if;
   end std_match;
@@ -2549,7 +2549,7 @@ package body std_ulogic_support is
       is
     constant arg_l: integer := arg'length-1;
     alias xarg: std_ulogic_vector(arg_l downto 0) is arg;
-    variable result: std_ulogic_vector(arg_l downto 0) ; 
+    variable result: std_ulogic_vector(arg_l downto 0) ;
     variable countm: integer;
     -- pragma built_in SYN_ROLU
   begin
@@ -2603,7 +2603,7 @@ package body std_ulogic_support is
     return std_ulogic_vector( xsrl( std_ulogic_vector(arg), count ) );
   end shift_right;
 
- 
+
   -- Id: S.5
   function rotate_left (arg: std_ulogic_vector; count: natural) return std_ulogic_vector is
     -- pragma built_in SYN_ROLU
@@ -2672,7 +2672,7 @@ package body std_ulogic_support is
 
 --==============================================================
   --End Shift and Rotate Functions
---============================================================== 
+--==============================================================
 
 end std_ulogic_support ;
 

--- a/rel/src/vhdl/ibm/std_ulogic_unsigned.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_unsigned.vhdl
@@ -71,18 +71,20 @@ package std_ulogic_unsigned is
   -- synopsys translate_off
   attribute type_convert        of to_integer : function is true;
   attribute btr_name            of to_integer : function is "PASS";
-  attribute pin_bit_information of to_integer : function is
-           (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
-            2 => ("   ","10      ","INCR","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of to_integer : function is
+  --         (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
+  --          2 => ("   ","10      ","INCR","PIN_BIT_SCALAR"));
   -- synopsys translate_on
 
   -- synopsys translate_off
   function to_std_ulogic_vector( d : natural; w : positive ) return std_ulogic_vector;
   attribute type_convert        of to_std_ulogic_vector : function is true;
   attribute btr_name            of to_std_ulogic_vector : function is "PASS";
-  attribute pin_bit_information of to_std_ulogic_vector : function is
-           (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
-            2 => ("   ","10      ","INCR","PIN_BIT_SCALAR"));
+  -- FIXME: GHDL with LLVM backend crashes here (see https://github.com/ghdl/ghdl/issues/1772)
+  --attribute pin_bit_information of to_std_ulogic_vector : function is
+  --         (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
+  --          2 => ("   ","10      ","INCR","PIN_BIT_SCALAR"));
   -- synopsys translate_on
 
 end std_ulogic_unsigned;

--- a/rel/src/vhdl/ibm/std_ulogic_unsigned.vhdl
+++ b/rel/src/vhdl/ibm/std_ulogic_unsigned.vhdl
@@ -52,7 +52,7 @@ package std_ulogic_unsigned is
   function "<="( l : std_ulogic_vector; r : natural)          return boolean;
   function ">" ( l : std_ulogic_vector; r : natural)          return boolean;
   function ">="( l : std_ulogic_vector; r : natural)          return boolean;
-  
+
   function "=" ( l : natural;          r : std_ulogic_vector) return std_ulogic;
   function "/="( l : natural;          r : std_ulogic_vector) return std_ulogic;
   function "<" ( l : natural;          r : std_ulogic_vector) return std_ulogic;
@@ -75,7 +75,7 @@ package std_ulogic_unsigned is
            (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
             2 => ("   ","10      ","INCR","PIN_BIT_SCALAR"));
   -- synopsys translate_on
-  
+
   -- synopsys translate_off
   function to_std_ulogic_vector( d : natural; w : positive ) return std_ulogic_vector;
   attribute type_convert        of to_std_ulogic_vector : function is true;
@@ -84,7 +84,7 @@ package std_ulogic_unsigned is
            (1 => ("   ","A0      ","INCR","PIN_BIT_SCALAR"),
             2 => ("   ","10      ","INCR","PIN_BIT_SCALAR"));
   -- synopsys translate_on
-  
+
 end std_ulogic_unsigned;
 
 package body std_ulogic_unsigned is
@@ -131,7 +131,7 @@ package body std_ulogic_unsigned is
            result := std_ulogic_vector( UNSIGNED(L) + 1 );
         else
            result := L;
-        end if; 
+        end if;
         return result ;
     end;
 
@@ -143,7 +143,7 @@ package body std_ulogic_unsigned is
            result := std_ulogic_vector( UNSIGNED(R) + 1 );
         else
            result := R;
-        end if; 
+        end if;
         return result ;
     end;
 
@@ -217,130 +217,130 @@ package body std_ulogic_unsigned is
   begin
     return l = unsigned(r);
   end "=";
-  
+
   function "/="( l : natural;          r : std_ulogic_vector) return boolean is
   begin
     return l /= unsigned(r);
   end "/=";
-  
+
   function "<" ( l : natural;          r : std_ulogic_vector) return boolean is
   begin
     return l < unsigned(r);
   end "<";
-  
+
   function "<="( l : natural;          r : std_ulogic_vector) return boolean is
   begin
     return l <= unsigned(r);
   end "<=";
-  
+
   function ">" ( l : natural;          r : std_ulogic_vector) return boolean is
   begin
     return l > unsigned(r);
   end ">";
-  
+
   function ">="( l : natural;          r : std_ulogic_vector) return boolean is
   begin
     return l >= unsigned(r);
   end ">=";
-  
+
   function "=" ( l : std_ulogic_vector; r : natural)          return boolean is
   begin
     return unsigned(l) = r;
   end "=";
-  
+
   function "/="( l : std_ulogic_vector; r : natural)          return boolean is
   begin
     return unsigned(l) /= r;
   end "/=";
-  
+
   function "<" ( l : std_ulogic_vector; r : natural)          return boolean is
   begin
     return unsigned(l) < r;
   end "<";
-  
+
   function "<="( l : std_ulogic_vector; r : natural)          return boolean is
   begin
     return unsigned(l) <= r;
   end "<=";
-  
+
   function ">" ( l : std_ulogic_vector; r : natural)          return boolean is
   begin
     return unsigned(l) > r;
   end ">";
-  
+
   function ">="( l : std_ulogic_vector; r : natural)          return boolean is
   begin
     return unsigned(l) >= r;
   end ">=";
-  
+
   function "=" ( l : natural;          r : std_ulogic_vector) return std_ulogic is
   begin
     return tconv( l = unsigned(r) );
   end "=";
-  
+
   function "/="( l : natural;          r : std_ulogic_vector) return std_ulogic is
   begin
     return tconv( l /= unsigned(r) );
   end "/=";
-  
+
   function "<" ( l : natural;          r : std_ulogic_vector) return std_ulogic is
   begin
     return tconv( l < unsigned(r) );
   end "<";
-  
+
   function "<="( l : natural;          r : std_ulogic_vector) return std_ulogic is
   begin
     return tconv( l <= unsigned(r) );
   end "<=";
-  
+
   function ">" ( l : natural;          r : std_ulogic_vector) return std_ulogic is
   begin
     return tconv( l > unsigned(r) );
   end ">";
-  
+
   function ">="( l : natural;          r : std_ulogic_vector) return std_ulogic is
   begin
     return tconv( l >= unsigned(r) );
   end ">=";
-  
+
   function "=" ( l : std_ulogic_vector; r : natural)          return std_ulogic is
   begin
     return tconv( unsigned(l) = r );
   end "=";
-  
+
   function "/="( l : std_ulogic_vector; r : natural)          return std_ulogic is
   begin
     return tconv( unsigned(l) /= r );
   end "/=";
-  
+
   function "<" ( l : std_ulogic_vector; r : natural)          return std_ulogic is
   begin
     return tconv( unsigned(l) < r );
   end "<";
-  
+
   function "<="( l : std_ulogic_vector; r : natural)          return std_ulogic is
   begin
     return tconv( unsigned(l) <= r );
   end "<=";
-  
+
   function ">" ( l : std_ulogic_vector; r : natural)          return std_ulogic is
   begin
     return tconv( unsigned(l) > r );
   end ">";
-  
+
   function ">="( l : std_ulogic_vector; r : natural)          return std_ulogic is
   begin
     return tconv( unsigned(l) >= r );
   end ">=";
-  
+
   function to_integer( d : std_ulogic_vector ) return natural is
   begin
     return tconv( d );
   end to_integer;
-  
+
   function to_std_ulogic_vector( d : natural; w : positive ) return std_ulogic_vector is
   begin
     return tconv( d, w );
   end to_std_ulogic_vector;
-  
+
 end std_ulogic_unsigned;


### PR DESCRIPTION
Instead of testing compilation with GHDL's mcode backend only, this PR adds another job for testing with GHDL's LLVM backend too. However, GHDL LLVM chokes on the usage of `pin_bit_information` in libraries `ibm` and `clib`. I asked Tristan about it in ghdl/ghdl#1772.

The last commit in this PR comments all those attributes so that GHDL can analyse/elaborate them. Yet, Tristan commented:

> https://github.com/ghdl/ghdl/issues/1772#issuecomment-846850529
> 
> But in fact the aggregate is not valid.  The type is an array of an array of a string, but the length of the strings is not the same.
> 
> This is not the reason of the crash, but even if the feature were handled, the source won't be analyzed successfully.

Therefore, I will mark this PR as draft, for discussion. If those attributes are used 200+ times in this codebase, I would expect them to be supported in whichever internal VHDL simulator/synthesiser used in IBM.